### PR TITLE
ci: build and push docker on pull request

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
           - app-engine
           - cbir
           - core
-          # - iam
+          - iam
           # - mongo
           # - nginx
           - pims

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,7 +22,7 @@ jobs:
           # - mongo
           # - nginx
           - pims
-          # - postgis
+          - postgis
           - web-ui
 
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,9 +18,9 @@ jobs:
           - app-engine
           - cbir
           - core
-          - iam
-          # - mongo
-          # - nginx
+          # - iam
+          - mongo
+          - nginx
           - pims
           - postgis
           - web-ui

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,7 +22,7 @@ jobs:
           # - mongo
           # - nginx
           # - pims
-          # - postgis
+          - postgis
           - web-ui
 
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -20,7 +20,7 @@ jobs:
           - core
           # - iam
           # - mongo
-          - nginx
+          # - nginx
           - pims
           # - postgis
           - web-ui

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -20,9 +20,9 @@ jobs:
           - core
           # - iam
           - mongo
-          - nginx
+          # - nginx
           - pims
-          - postgis
+          # - postgis
           - web-ui
 
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,14 +15,14 @@ jobs:
       fail-fast: true
       matrix:
         image:
-          - app-engine
-          - cbir
-          - core
-          - iam
-          - mongo
-          - nginx
-          - pims
-          - postgis
+          # - app-engine
+          # - cbir
+          # - core
+          # - iam
+          # - mongo
+          # - nginx
+          # - pims
+          # - postgis
           - web-ui
 
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,8 +19,8 @@ jobs:
           - cbir
           - core
           # - iam
-          - mongo
-          # - nginx
+          # - mongo
+          - nginx
           - pims
           # - postgis
           - web-ui

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,13 +15,13 @@ jobs:
       fail-fast: true
       matrix:
         image:
-          # - app-engine
-          # - cbir
-          # - core
+          - app-engine
+          - cbir
+          - core
           # - iam
-          # - mongo
-          # - nginx
-          # - pims
+          - mongo
+          - nginx
+          - pims
           - postgis
           - web-ui
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,50 @@
+name: PR
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-push:
+    runs-on: self-hosted
+
+    strategy:
+      fail-fast: true
+      matrix:
+        image:
+          - app-engine
+          - cbir
+          - core
+          - iam
+          - mongo
+          - nginx
+          - pims
+          - postgis
+          - web-ui
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Cytomine registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cytomine.org
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.image }}
+          file: ./${{ matrix.image }}/Dockerfile
+          push: true
+          tags: registry.cytomine.org/cytomine/${{ matrix.image }}
+          allow: network.host
+          network: host

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
           - app-engine
           - cbir
           - core
-          # - iam
+          - iam
           - mongo
           - nginx
           - pims

--- a/app-engine/Dockerfile
+++ b/app-engine/Dockerfile
@@ -5,10 +5,11 @@ ARG ENTRYPOINT_SCRIPTS_VERSION=1.4.0
 ARG GRADLE_VERSION=7.6.4-jdk17-alpine
 ARG GRADLE_DEV_VERSION=7.6.4-jdk17-jammy
 ARG OPENJDK_VERSION=17-slim-bullseye
+ARG PROXY_CACHE=registry.cytomine.org/docker
 
 #######################################################################################
 # Stage: dependencies download via gradle
-FROM gradle:${GRADLE_VERSION} AS deps-downloader
+FROM ${PROXY_CACHE}/gradle:${GRADLE_VERSION} AS deps-downloader
 
 # We first copy the build.gradle file and the binaries stored in the source repository.
 # This way, we retrieve all gradle dependencies at the beginning. All these steps will be
@@ -25,7 +26,7 @@ RUN gradle clean compileJava --no-daemon --console=verbose
 
 #######################################################################################
 ## Stage: building the jar file
-FROM gradle:${GRADLE_VERSION} AS jar-builder
+FROM ${PROXY_CACHE}/gradle:${GRADLE_VERSION} AS jar-builder
 
 ENV GRADLE_USER_HOME=/opt/gradle/.gradle
 COPY --from=deps-downloader /opt/gradle/.gradle /opt/gradle/.gradle
@@ -43,11 +44,11 @@ RUN sed -i -- "s/version: ce-0.0.0/version: ${APP_ENGINE_VERSION}/g" /app/src/ma
 
 #######################################################################################
 ## Stage: entrypoint script. Use a multi-stage because COPY --from cannot interpolate variables
-FROM cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
+FROM ${PROXY_CACHE}/cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
 
 #######################################################################################
 ## Stage: App-Engine development image
-FROM gradle:${GRADLE_DEV_VERSION} AS dev-server
+FROM ${PROXY_CACHE}/gradle:${GRADLE_DEV_VERSION} AS dev-server
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -68,7 +69,7 @@ ENTRYPOINT ["cytomine-entrypoint.sh"]
 
 #######################################################################################
 ## Stage: Cytomine core image
-FROM openjdk:${OPENJDK_VERSION} AS production
+FROM ${PROXY_CACHE}/openjdk:${OPENJDK_VERSION} AS production
 
 ARG APP_ENGINE_VERSION
 ARG APP_ENGINE_REVISION

--- a/cbir/Dockerfile
+++ b/cbir/Dockerfile
@@ -1,11 +1,13 @@
-FROM python:3.10-slim-bullseye AS base
+ARG PROXY_CACHE=registry.cytomine.org/docker
+
+FROM ${PROXY_CACHE}/python:3.10-slim-bullseye AS base
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY cbir /app/cbir
-COPY pyproject.toml poetry.lock README.md /app
+COPY pyproject.toml poetry.lock README.md /app/
 COPY weights/resnet /app/weights/resnet
 
 WORKDIR /app

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -3,10 +3,11 @@ ARG CORE_VERSION
 ARG CORE_REVISION
 ARG GRADLE_VERSION=7.6-jdk17
 ARG OPENJDK_VERSION=17-slim-bullseye
+ARG PROXY_CACHE=registry.cytomine.org/docker
 
 #######################################################################################
 # Stage: core dependencies download via gradle
-FROM gradle:${GRADLE_VERSION}-alpine AS deps-downloader
+FROM ${PROXY_CACHE}/gradle:${GRADLE_VERSION}-alpine AS deps-downloader
 
 # We first copy the build.gradle file and the binaries stored in the source repository.
 # This way, we retrieve all gradle dependencies at the beginning. All these steps will be
@@ -22,7 +23,7 @@ RUN gradle clean build --no-daemon --console=verbose
 
 #######################################################################################
 ## Stage: building the core jar file
-FROM gradle:${GRADLE_VERSION}-alpine AS jar-builder
+FROM ${PROXY_CACHE}/gradle:${GRADLE_VERSION}-alpine AS jar-builder
 
 ENV GRADLE_USER_HOME=/opt/gradle/.gradle
 COPY --from=deps-downloader /opt/gradle/.gradle /opt/gradle/.gradle
@@ -39,7 +40,7 @@ RUN sed -i -- 's/version: 0.0.0/version: '$CORE_VERSION'/g' /app/src/main/resour
 
 #######################################################################################
 ## Stage: Cytomine core development image
-FROM gradle:${GRADLE_VERSION}-jammy AS dev-server
+FROM ${PROXY_CACHE}/gradle:${GRADLE_VERSION}-jammy AS dev-server
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -55,7 +56,7 @@ CMD ["/bin/sh"]
 
 #######################################################################################
 ## Stage: Cytomine core image
-FROM openjdk:${OPENJDK_VERSION} AS production
+FROM ${PROXY_CACHE}/openjdk:${OPENJDK_VERSION} AS production
 
 ARG CORE_VERSION
 ARG CORE_REVISION

--- a/iam/Dockerfile
+++ b/iam/Dockerfile
@@ -1,6 +1,7 @@
 # List ARGs here for better readability.
 ARG ENTRYPOINT_SCRIPTS_VERSION=1.4.0
 ARG KEYCLOAK_VERSION=24.0.2
+ARG PROXY_CACHE=registry.cytomine.org/docker
 ARG UBI_VERSION=9.3-1610
 ARG IMAGE_VERSION
 ARG IMAGE_REVISION
@@ -25,7 +26,7 @@ RUN /opt/keycloak/bin/kc.sh build
 
 #######################################################################################
 ## Stage: entrypoint script. Use a multi-stage because COPY --from cannot interpolate variables
-FROM cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
+FROM ${PROXY_CACHE}/cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
 
 #######################################################################################
 ## Stage: Cytomine IAM dev external tools build

--- a/iam/Dockerfile
+++ b/iam/Dockerfile
@@ -8,7 +8,7 @@ ARG IMAGE_REVISION
 
 #######################################################################################
 ## Stage: IAM build
-FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS builder
+FROM ${PROXY_CACHE}/quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS builder
 
 # Enable health and metrics support
 ENV KC_HEALTH_ENABLED=true
@@ -30,7 +30,7 @@ FROM ${PROXY_CACHE}/cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS
 
 #######################################################################################
 ## Stage: Cytomine IAM dev external tools build
-FROM registry.access.redhat.com/ubi9:${UBI_VERSION} AS dev-tools-builder
+FROM ${PROXY_CACHE}/registry.access.redhat.com/ubi9:${UBI_VERSION} AS dev-tools-builder
 RUN mkdir -p /mnt/rootfs
 RUN dnf install --installroot /mnt/rootfs findutils gettext openssh-server rsync --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
     dnf --installroot /mnt/rootfs clean all && \
@@ -43,7 +43,7 @@ COPY --from=entrypoint-scripts --chmod=774 /envsubst-on-templates-and-move.sh /d
 
 #######################################################################################
 ## Stage: Cytomine IAM development image
-FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS dev-server
+FROM ${PROXY_CACHE}/quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS dev-server
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 COPY --from=dev-tools-builder /mnt/rootfs /
@@ -60,7 +60,7 @@ CMD ["start-dev", "--import-realm"]
 
 #######################################################################################
 ## Stage: Cytomine IAM external tools build
-FROM registry.access.redhat.com/ubi9:${UBI_VERSION} AS prod-tools-builder
+FROM ${PROXY_CACHE}/registry.access.redhat.com/ubi9:${UBI_VERSION} AS prod-tools-builder
 RUN mkdir -p /mnt/rootfs
 RUN dnf install --installroot /mnt/rootfs findutils gettext --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
     dnf --installroot /mnt/rootfs clean all && \
@@ -72,7 +72,7 @@ COPY --from=entrypoint-scripts --chmod=774 /envsubst-on-templates-and-move.sh /d
 
 #######################################################################################
 ## Stage: Cytomine IAM image
-FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS ci
+FROM ${PROXY_CACHE}/quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS ci
 
 ARG ENTRYPOINT_SCRIPTS_VERSION
 ARG KEYCLOAK_VERSION
@@ -103,7 +103,7 @@ CMD ["start-dev" , "--import-realm" , "--http-port=8100"]
 
 #######################################################################################
 ## Stage: Cytomine IAM image
-FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS production
+FROM ${PROXY_CACHE}/quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS production
 
 ARG ENTRYPOINT_SCRIPTS_VERSION
 ARG KEYCLOAK_VERSION

--- a/iam/Dockerfile
+++ b/iam/Dockerfile
@@ -8,7 +8,7 @@ ARG IMAGE_REVISION
 
 #######################################################################################
 ## Stage: IAM build
-FROM ${PROXY_CACHE}/quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS builder
+FROM ${PROXY_CACHE}/keycloak/keycloak:${KEYCLOAK_VERSION} AS builder
 
 # Enable health and metrics support
 ENV KC_HEALTH_ENABLED=true
@@ -30,7 +30,7 @@ FROM ${PROXY_CACHE}/cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS
 
 #######################################################################################
 ## Stage: Cytomine IAM dev external tools build
-FROM ${PROXY_CACHE}/registry.access.redhat.com/ubi9:${UBI_VERSION} AS dev-tools-builder
+FROM ${PROXY_CACHE}/redhat/ubi9:${UBI_VERSION} AS dev-tools-builder
 RUN mkdir -p /mnt/rootfs
 RUN dnf install --installroot /mnt/rootfs findutils gettext openssh-server rsync --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
     dnf --installroot /mnt/rootfs clean all && \
@@ -43,7 +43,7 @@ COPY --from=entrypoint-scripts --chmod=774 /envsubst-on-templates-and-move.sh /d
 
 #######################################################################################
 ## Stage: Cytomine IAM development image
-FROM ${PROXY_CACHE}/quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS dev-server
+FROM ${PROXY_CACHE}/keycloak/keycloak:${KEYCLOAK_VERSION} AS dev-server
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 COPY --from=dev-tools-builder /mnt/rootfs /
@@ -60,7 +60,7 @@ CMD ["start-dev", "--import-realm"]
 
 #######################################################################################
 ## Stage: Cytomine IAM external tools build
-FROM ${PROXY_CACHE}/registry.access.redhat.com/ubi9:${UBI_VERSION} AS prod-tools-builder
+FROM ${PROXY_CACHE}/redhat/ubi9:${UBI_VERSION} AS prod-tools-builder
 RUN mkdir -p /mnt/rootfs
 RUN dnf install --installroot /mnt/rootfs findutils gettext --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
     dnf --installroot /mnt/rootfs clean all && \
@@ -72,7 +72,7 @@ COPY --from=entrypoint-scripts --chmod=774 /envsubst-on-templates-and-move.sh /d
 
 #######################################################################################
 ## Stage: Cytomine IAM image
-FROM ${PROXY_CACHE}/quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS ci
+FROM ${PROXY_CACHE}/keycloak/keycloak:${KEYCLOAK_VERSION} AS ci
 
 ARG ENTRYPOINT_SCRIPTS_VERSION
 ARG KEYCLOAK_VERSION
@@ -103,7 +103,7 @@ CMD ["start-dev" , "--import-realm" , "--http-port=8100"]
 
 #######################################################################################
 ## Stage: Cytomine IAM image
-FROM ${PROXY_CACHE}/quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS production
+FROM ${PROXY_CACHE}/keycloak/keycloak:${KEYCLOAK_VERSION} AS production
 
 ARG ENTRYPOINT_SCRIPTS_VERSION
 ARG KEYCLOAK_VERSION

--- a/mongo/Dockerfile
+++ b/mongo/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 # Copyright (c) 2009-2022. Authors: see NOTICE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mongo/Dockerfile
+++ b/mongo/Dockerfile
@@ -18,13 +18,14 @@ ARG MONGO_VERSION=4.4-focal
 ARG ENTRYPOINT_SCRIPTS_VERSION=1.3.0
 ARG IMAGE_VERSION
 ARG IMAGE_REVISION
+ARG PROXY_CACHE=registry.cytomine.org/docker
 
 #######################################################################################
 ## Stage 1: entrypoint script. Use a multi-stage because COPY --from cannot interpolate variables
-FROM cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
+FROM ${PROXY_CACHE}/cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
 
 ## Stage 2: mongo image
-FROM mongo:${MONGO_VERSION}
+FROM ${PROXY_CACHE}/mongo:${MONGO_VERSION}
 
 RUN rm /etc/apt/sources.list.d/mongodb*.list && apt-get update && apt-get install -y --no-install-recommends cron
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -18,13 +18,14 @@ ARG ENTRYPOINT_SCRIPTS_VERSION=1.3.0
 ARG IMAGE_VERSION
 ARG IMAGE_REVISION
 ARG NGINX_VERSION="1.22.1"
+ARG PROXY_CACHE=registry.cytomine.org/docker
 
 #######################################################################################
 ## Stage: entrypoint script. Use a multi-stage because COPY --from cannot interpolate variables
-FROM cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
+FROM ${PROXY_CACHE}/cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
 
 ## Stage: nginx
-FROM nginx:${NGINX_VERSION}-alpine AS nginx-server
+FROM ${PROXY_CACHE}/nginx:${NGINX_VERSION}-alpine AS nginx-server
 
 ENV IMAGES_CORE="not provided"
 ENV IMAGES_MONGO="not provided"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 # Copyright (c) 2009-2022. Authors: see NOTICE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pims/Dockerfile
+++ b/pims/Dockerfile
@@ -5,6 +5,7 @@ ARG OPENJPEG_VERSION=2.5.2
 ARG PIMS_REVISION
 ARG PIMS_VERSION
 ARG PLUGIN_CSV=scripts/plugin-list.csv
+ARG PROXY_CACHE=registry.cytomine.org/docker
 ARG PY_VERSION=3.10
 ARG SETUPTOOLS_VERSION=80.9.0
 ARG UBUNTU_VERSION=22.04
@@ -13,7 +14,7 @@ ARG VIPS_VERSION=8.15.2
 
 #######################################################################################
 ## Stage: Pims
-FROM python:${PY_VERSION}-bookworm AS base-pims
+FROM ${PROXY_CACHE}/python:${PY_VERSION}-bookworm AS base-pims
 
 ARG GUNICORN_VERSION
 ARG OPENJPEG_URL

--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 # Copyright (c) 2009-2022. Authors: see NOTICE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -22,7 +22,7 @@ ARG POSTGIS_VERSION="15-3.3-alpine"
 
 #######################################################################################
 ## Stage: entrypoint script. Use a multi-stage because COPY --from cannot interpolate variables
-FROM cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
+FROM ${PROXY_CACHE}/cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
 
 FROM ${PROXY_CACHE}/postgis/postgis:${POSTGIS_VERSION}
 ARG ENTRYPOINT_SCRIPTS_VERSION

--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG PROXY_CACHE=registry.cytomine.org/docker
 ARG ENTRYPOINT_SCRIPTS_VERSION="1.3.0"
 ARG IMAGE_VERSION
 ARG IMAGE_REVISION
@@ -23,7 +24,7 @@ ARG POSTGIS_VERSION="15-3.3-alpine"
 ## Stage: entrypoint script. Use a multi-stage because COPY --from cannot interpolate variables
 FROM cytomine/entrypoint-scripts:${ENTRYPOINT_SCRIPTS_VERSION} AS entrypoint-scripts
 
-FROM postgis/postgis:${POSTGIS_VERSION}
+FROM ${PROXY_CACHE}/postgis/postgis:${POSTGIS_VERSION}
 ARG ENTRYPOINT_SCRIPTS_VERSION
 ARG IMAGE_VERSION
 ARG IMAGE_REVISION

--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG PROXY_CACHE=registry.cytomine.org/docker
 ARG WEB_UI_VERSION
 ARG WEB_UI_REVISION
 ARG NODE_VERSION=20.19.4
@@ -20,7 +21,7 @@ ARG NGINX_VERSION=1.22.1
 
 #######################################################################################
 ## Stage: build front-end
-FROM node:${NODE_VERSION}-alpine AS frontend-builder
+FROM ${PROXY_CACHE}/node:${NODE_VERSION}-alpine AS frontend-builder
 
 WORKDIR /app
 
@@ -45,7 +46,7 @@ RUN npm install && npm run build -w ui
 
 #######################################################################################
 ## Stage: dev image (with hot swap)
-FROM node:${NODE_VERSION}-bookworm-slim AS dev-server
+FROM ${PROXY_CACHE}/node:${NODE_VERSION}-bookworm-slim AS dev-server
 
 WORKDIR /app
 
@@ -55,7 +56,7 @@ CMD ["npm", "run", "serve", "-w", "ui"]
 
 #######################################################################################
 ## Stage: building nginx image serving the front-end
-FROM nginx:${NGINX_VERSION}-alpine AS prod-server
+FROM ${PROXY_CACHE}/nginx:${NGINX_VERSION}-alpine AS prod-server
 
 ARG WEB_UI_VERSION
 ARG WEB_UI_REVISION


### PR DESCRIPTION
## Summary of Changes

- Add prefix `${PROXY_CACHE}/` to all base images in the Dockerfile of the services
- Change registries from `quay.io` and `registry.access.redhat.com` to `Docker Hub` for IAM Dockerfile
- On pull request, build Docker images for all the services and push them to the local registry under the `cytomine` project


---

closes cytomine/planning#82
closes cytomine/planning#87