### PR TITLE
ci: publish python client to pypi

### DIFF
--- a/.github/workflows/client-python.yaml
+++ b/.github/workflows/client-python.yaml
@@ -46,3 +46,49 @@ jobs:
 
       - name: Check type
         run: uv run mypy cytomine tests
+
+  check-version:
+    if: github.ref_name == 'main' && github.event_name == 'push'
+    runs-on: self-hosted
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+
+    steps:
+      - name: Set up the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check version change
+        id: check
+        run: |
+          CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          PREVIOUS_VERSION=$(git show HEAD~1:clients/python/pyproject.toml | grep '^version = ' | sed 's/version = "\(.*\)"/\1/' || echo "")
+
+          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "Version unchanged"
+          fi
+
+  publish:
+    if: needs.check-version.outputs.changed == 'true'
+    needs: check-version
+    runs-on: self-hosted
+
+    steps:
+      - name: Set up the repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ vars.UV_VERSION }}
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish package
+        run: uv publish


### PR DESCRIPTION
It should only publish a new version when the version is changed in pyproject.toml and pushed on `main`.

closes #136 