### PR TITLE
fix-image-provisioning

### DIFF
--- a/core/src/main/java/be/cytomine/service/appengine/TaskRunService.java
+++ b/core/src/main/java/be/cytomine/service/appengine/TaskRunService.java
@@ -290,7 +290,7 @@ public class TaskRunService {
                 throw new IllegalArgumentException("Unsupported type: " + type);
             }
 
-            String response = appEngineService.put(uri, body, MediaType.MULTIPART_FORM_DATA);
+            String response = appEngineService.post(uri, body, MediaType.MULTIPART_FORM_DATA);
 
             if (wsi != null) {
                 wsi.delete();


### PR DESCRIPTION
closes #279 

pay attention to the volumes .. these 4 must all be the same thing for `local` mode to run correctly :
```yml
app-engine:
    image: cytomine/app-engine:latest
    restart: unless-stopped
    depends_on:
      - postgis
      - registry
      - k3s
    volumes:
      - ${DATA_PATH:-./data}/app-engine:/data
      - ${PWD}/.kube/shared:/root/.kube:ro
      # 1
      - /home/siddig-hamed/egress_recordings/cytomine/data/app-engine:/home/siddig-hamed/egress_recordings/cytomine/data/app-engine
      - ${DATA_PATH:-./data}/app-engine-shared-datasets:/app-engine-shared-datasets:rw
    environment:
      API_PREFIX: ${APP_ENGINE_API_BASE_PATH:-/app-engine/}
      DB_HOST: postgis
      DB_NAME: appengine
      DB_PASSWORD: password
      DB_PORT: 5432
      DB_USERNAME: appengine
      REGISTRY_URL: http://registry:5000
      # 2
      STORAGE_BASE_PATH: /home/siddig-hamed/egress_recordings/cytomine/data/app-engine
      # 3
      RUN_STORAGE_BASE_PATH: /home/siddig-hamed/egress_recordings/cytomine/data/app-engine
      REF_STORAGE_BASE_PATH: /app-engine-shared-datasets
      SCHEDULER_RUN_MODE: local # values: local, cluster
      SCHEDULER_ADVERTISED_URL: http://172.16.238.10:8080
      SCHEDULER_REGISTRY_ADVERTISED_URL: 172.16.238.4:5000
      SCHEDULER_USE_HOST_NETWORK: true
      SCHEDULER_TASKS_NAMESPACE: app-engine-tasks
      KUBERNETES_MASTER: https://k3s:6443/
    networks:
      host_network:
        ipv4_address: 172.16.238.10
 ```

also in `k3s`
```yml
k3s:
    image: "rancher/k3s:v1.30.14-rc3-k3s3"
    command: server
    tmpfs:
      - /run
      - /var/run
    ulimits:
      nproc: 65535
      nofile:
        soft: 65535
        hard: 65535
    privileged: true
    restart: always
    environment:
      - K3S_TOKEN=65535-65535-65535 # plain text secret!
      - K3S_KUBECONFIG_OUTPUT=/output/config
      - K3S_KUBECONFIG_MODE=666
    volumes:
      - k3s-server:/var/lib/rancher/k3s
      - ./k3s/registries.yaml:/etc/rancher/k3s/registries.yaml:ro
      - ./k3s/serviceaccounts.yaml://var/lib/rancher/k3s/server/manifests/serviceaccounts.yaml:ro
      # 4
      - /home/siddig-hamed/egress_recordings/cytomine/data/app-engine:/home/siddig-hamed/egress_recordings/cytomine/data/app-engine
      - ${DATA_PATH:-./data}/app-engine-shared-datasets:/app-engine-shared-datasets:ro
      # This is just so that we get the kubeconfig file out
      - .kube/shared:/output/
    ports:
      - 6443:6443
    networks:
      host_network:
        ipv4_address: 172.16.238.15
 ```       