### PR TITLE
chore: use Eclipse Terumin as base image

### DIFF
--- a/app-engine/Dockerfile
+++ b/app-engine/Dockerfile
@@ -2,9 +2,9 @@
 ARG APP_ENGINE_VERSION
 ARG APP_ENGINE_REVISION
 ARG ENTRYPOINT_SCRIPTS_VERSION=1.4.0
+ARG JAVA_VERSION=17-jre
 ARG GRADLE_VERSION=7.6.4-jdk17-alpine
 ARG GRADLE_DEV_VERSION=7.6.4-jdk17-jammy
-ARG OPENJDK_VERSION=17-slim-bullseye
 ARG PROXY_CACHE=registry.cytomine.org/docker
 
 #######################################################################################
@@ -74,22 +74,23 @@ ENTRYPOINT ["cytomine-entrypoint.sh"]
 
 #######################################################################################
 ## Stage: Cytomine core image
-FROM ${PROXY_CACHE}/openjdk:${OPENJDK_VERSION} AS production
+FROM ${PROXY_CACHE}/eclipse-temurin:${JAVA_VERSION} AS production
 
 ARG APP_ENGINE_VERSION
 ARG APP_ENGINE_REVISION
 ARG ENTRYPOINT_SCRIPTS_VERSION
+ARG JAVA_VERSION
 ARG GRADLE_VERSION
-ARG OPENJDK_VERSION
 
-LABEL org.opencontainers.image.authors="dev@cytomine.com" \
+LABEL org.opencontainers.image.authors="uliege@cytomine.org" \
       org.opencontainers.image.url="https://uliege.cytomine.org/" \
       org.opencontainers.image.documentation="https://doc.cytomine.com/" \
-      org.opencontainers.image.source="https://github.com/cytomine/Cytomine-app-engine" \
+      org.opencontainers.image.source="https://github.com/cytomine/cytomine/tree/main/app-engine" \
       org.opencontainers.image.vendor="Cytomine ULiege" \
       org.opencontainers.image.version="${APP_ENGINE_VERSION}" \
       org.opencontainers.image.revision="${APP_ENGINE_REVISION}" \
-      org.opencontainers.image.deps.openjdk.version="${OPENJDK_VERSION}" \
+      org.opencontainers.image.deps.java.distribution="eclipse-temurin" \
+      org.opencontainers.image.deps.java.version="${JAVA_VERSION}" \
       org.opencontainers.image.deps.gradle.version="${GRADLE_VERSION}" \
       org.opencontainers.image.deps.entrypoint.scripts.version="${ENTRYPOINT_SCRIPTS_VERSION}"
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,8 +1,8 @@
 # List ARGs here for better readability.
 ARG CORE_VERSION
 ARG CORE_REVISION
+ARG JAVA_VERSION=17-jre
 ARG GRADLE_VERSION=7.6-jdk17
-ARG OPENJDK_VERSION=17-slim-bullseye
 ARG PROXY_CACHE=registry.cytomine.org/docker
 
 #######################################################################################
@@ -56,21 +56,22 @@ CMD ["/bin/sh"]
 
 #######################################################################################
 ## Stage: Cytomine core image
-FROM ${PROXY_CACHE}/openjdk:${OPENJDK_VERSION} AS production
+FROM ${PROXY_CACHE}/eclipse-temurin:${JAVA_VERSION} AS production
 
 ARG CORE_VERSION
 ARG CORE_REVISION
+ARG JAVA_VERSION
 ARG GRADLE_VERSION
-ARG OPENJDK_VERSION
 
-LABEL org.opencontainers.image.authors="dev@cytomine.com" \
+LABEL org.opencontainers.image.authors="uliege@cytomine.org" \
       org.opencontainers.image.url="https://uliege.cytomine.org/" \
       org.opencontainers.image.documentation="https://doc.uliege.cytomine.org/" \
-      org.opencontainers.image.source="https://github.com/cytomine/Cytomine-core" \
+      org.opencontainers.image.source="https://github.com/cytomine/cytomine/tree/main/core" \
       org.opencontainers.image.vendor="Cytomine ULiège" \
       org.opencontainers.image.version="${CORE_VERSION}" \
       org.opencontainers.image.revision="${CORE_REVISION}" \
-      org.opencontainers.image.deps.openjdk.version="${OPENJDK_VERSION}" \
+      org.opencontainers.image.deps.java.distribution="eclipse-temurin" \
+      org.opencontainers.image.deps.java.version="${JAVA_VERSION}" \
       org.opencontainers.image.deps.gradle.version="${GRADLE_VERSION}"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -79,8 +80,8 @@ ENV LANG=C.UTF-8
 # base librairies and configuration
 RUN apt-get update -y \
     && apt-get install --no-install-recommends --no-install-suggests -y \
-      logrotate=3.18* \
-      gettext=0.21* \
+      logrotate \
+      gettext \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i "/su root syslog/c\su root root" /etc/logrotate.conf
 


### PR DESCRIPTION
The base image of OpenJDK is deprecated, see https://hub.docker.com/_/openjdk#deprecation-notice and https://github.com/docker-library/openjdk/issues/505.