### PR TITLE
refactor(web-ui): enhance SAM annotation refinement responsiveness

### DIFF
--- a/web-ui/src/components/viewer/interactions/DrawInteraction.vue
+++ b/web-ui/src/components/viewer/interactions/DrawInteraction.vue
@@ -206,8 +206,12 @@ export default {
         if (this.activeTool === 'magic-wand') {
           try {
             const annotationId = annot.id;
-            await Cytomine.instance.api.post(`annotations/${annotationId}/refine`);
-            this.$emit('reloadAnnotations', {idImage: this.image.id});
+            const annotation = (await Cytomine.instance.api.post(`annotations/${annotationId}/refine`)).data;
+
+            this.$store.commit(this.imageModule + 'addAction', {annotation, type: Action.UPDATE});
+
+            this.$eventBus.$emit('editAnnotation', annotation);
+            this.$eventBus.$emit('reloadAnnotationCrop', annotation);
             this.$notify({type: 'success', text: 'Successful SAM Processing !'});
           } catch (error) {
             console.error(error);


### PR DESCRIPTION
closes #346 

Previously, when the SAM service finished refining an annotation, the refined annotation would not be updated in the web-ui until the next refresh interval. With this PR, the annotation updates instantly once the refinement completes.