### PR TITLE
fix(core): task run outputs

### DIFF
--- a/core/src/main/java/be/cytomine/service/appengine/TaskRunService.java
+++ b/core/src/main/java/be/cytomine/service/appengine/TaskRunService.java
@@ -477,7 +477,7 @@ public class TaskRunService {
         AnnotationLayer annotationLayer = annotationLayerService.createAnnotationLayer(layerName);
         TaskRunLayer taskRunLayer = taskRunLayerRepository
                 .findByTaskRunAndImage(taskRun, taskRun.getImage())
-                .orElseThrow(() -> new ObjectNotFoundException("Task run", taskRunId));
+                .orElse(new TaskRunLayer());
 
         for (String geometry : geometries) {
             String wktGeometry = geometryService.GeoJSONToWKT(geometry);


### PR DESCRIPTION
Adresses #425 

When there is no geometry as output, there is no `task run layer` created.
Therefore, the intended behaviour is to continue its execution instead of throwing an error.