### PR TITLE
fix: remove filter on annotations for task input

### DIFF
--- a/web-ui/src/components/annotations/AnnotationSelection.vue
+++ b/web-ui/src/components/annotations/AnnotationSelection.vue
@@ -68,7 +68,6 @@ export default {
       return new AnnotationCollection({
         project: this.project.id,
         image: this.imageIds,
-        terms: this.terms.map(term => term.id),
         showWKT: true,
         max: this.nbPerPage,
       });
@@ -92,9 +91,6 @@ export default {
     },
     layersIds() {
       return this.layers.map(layer => layer.id);
-    },
-    terms() {
-      return this.$store.getters['currentProject/terms'] || [];
     },
   },
   watch: {

--- a/web-ui/tests/unit/components/annotations/AnnotationSelection.test.js
+++ b/web-ui/tests/unit/components/annotations/AnnotationSelection.test.js
@@ -20,9 +20,8 @@ describe('AnnotationSelection.vue', () => {
     {id: 2, name: 'Annotation 2'},
   ];
   const mockImages = [{imageInstance: {id: 1}}];
-  const mockedTerms = [{id: 1, name: 'Term 1'}];
 
-  const createWrapper = (options = {}) => {
+  const createWrapper = () => {
     return shallowMount(AnnotationSelection, {
       propsData: {
         active: true,
@@ -45,7 +44,6 @@ describe('AnnotationSelection.vue', () => {
         $store: {
           getters: {
             'currentProject/currentViewer': {images: mockImages},
-            'currentProject/terms': options.terms || [],
           },
         },
         $t: (message) => message,
@@ -106,19 +104,5 @@ describe('AnnotationSelection.vue', () => {
 
     expect(wrapper.vm.selectedAnnotation).toBe(null);
     expect(wrapper.emitted('update:active')).toEqual([[false]]);
-  });
-
-  describe('terms', () => {
-    it('should load an empty array when no term is provided', () => {
-      const wrapper = createWrapper({terms: []});
-
-      expect(wrapper.vm.terms).toEqual([]);
-    });
-
-    it('should load the terms data correctly', async () => {
-      const wrapper = createWrapper({terms: mockedTerms});
-
-      expect(wrapper.vm.terms).toEqual(mockedTerms);
-    });
   });
 });


### PR DESCRIPTION
Addresses #443 

The issue was that the annotations were filtered if some annotations have at least one term. This is why we see only 11 annotations in https://production.cytomine.org/#/project/115/image/57327, because there is only 11 annotations with terms. I remove the filter based on the terms so all annotations are taken into account