### PR TITLE
fix(helm): add redis data storage

### DIFF
--- a/helm/charts/cytomine/templates/redis_cbir/redis.yaml
+++ b/helm/charts/cytomine/templates/redis_cbir/redis.yaml
@@ -34,8 +34,26 @@ spec:
             - name: http
               containerPort: {{ .Values.redis.port }}
           volumeMounts:
+            - name: redis-storage
+              mountPath: /data
             - name: temp
               mountPath: /tmp
       volumes:
       - emptyDir: {}
         name: temp
+      {{ if not .Values.redis.storage.storageClassName -}}
+      - name: redis-storage
+        emptyDir: {}
+      {{ end }}
+  {{ if .Values.redis.storage.storageClassName -}}
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-storage
+      spec:
+        storageClassName: {{ .Values.redis.storage.storageClassName }}
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage.size }}
+  {{- end }}

--- a/helm/charts/cytomine/values.yaml
+++ b/helm/charts/cytomine/values.yaml
@@ -130,6 +130,9 @@ pims_cache:
 
 redis:
   port: 6379
+  storage:
+    size: 1Gi
+    storageClassName: null
 
 # Core - Main Cytomine Server
 core:


### PR DESCRIPTION
With #514, the redis database need write access to a persistent volume for cbir.

Logs from production server:
```
1:C 09 Jan 2026 08:33:51.654 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 09 Jan 2026 08:33:51.654 * Redis version=7.4.7, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 09 Jan 2026 08:33:51.654 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
1:M 09 Jan 2026 08:33:51.654 * monotonic clock: POSIX clock_gettime
1:M 09 Jan 2026 08:33:51.657 * Running mode=standalone, port=6379.
1:M 09 Jan 2026 08:33:51.657 * Server initialized
1:M 09 Jan 2026 08:33:51.657 * Ready to accept connections tcp
1:M 09 Jan 2026 12:59:42.636 * 1 changes in 3600 seconds. Saving...
1:M 09 Jan 2026 12:59:42.637 * Background saving started by pid 14
14:C 09 Jan 2026 12:59:42.638 # Failed opening the temp RDB file temp-14.rdb (in server root dir /data) for saving: Permission denied
1:M 09 Jan 2026 12:59:42.738 # Background saving error
1:M 09 Jan 2026 12:59:48.061 * 1 changes in 3600 seconds. Saving...
1:M 09 Jan 2026 12:59:48.062 * Background saving started by pid 15
15:C 09 Jan 2026 12:59:48.062 # Failed opening the temp RDB file temp-15.rdb (in server root dir /data) for saving: Permission denied
1:M 09 Jan 2026 12:59:48.163 # Background saving error
1:M 09 Jan 2026 12:59:54.091 * 1 changes in 3600 seconds. Saving...
1:M 09 Jan 2026 12:59:54.092 * Background saving started by pid 16
16:C 09 Jan 2026 12:59:54.092 # Failed opening the temp RDB file temp-16.rdb (in server root dir /data) for saving: Permission denied
1:M 09 Jan 2026 12:59:54.193 # Background saving error
```