### PR TITLE
fix: pims job import tmp storage

### DIFF
--- a/helm/charts/cytomine/templates/pims/pims-job-import.yaml
+++ b/helm/charts/cytomine/templates/pims/pims-job-import.yaml
@@ -74,9 +74,13 @@ spec:
             volumeMounts:
             - name: data
               mountPath: /data
+            - name: temp
+              mountPath: /tmp
           volumes:
-          - emptyDir: {}
-            name: data
+          - name: data
+            emptyDir: {}
+          - name: temp
+            emptyDir: {}
           restartPolicy: Never
       backoffLimit: 1
 {{- end }}


### PR DESCRIPTION
The pims job import is failing because it needs a temporary folder on production server
```
Traceback (most recent call last):
  File "/app/examples/import_datasets.py", line 44, in <module>
    with Cytomine(
         ^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cytomine/cytomine.py", line 274, in __init__
    self._start()
  File "/usr/local/lib/python3.12/site-packages/cytomine/cytomine.py", line 453, in _start
    self.set_current_user()
  File "/usr/local/lib/python3.12/site-packages/cytomine/cytomine.py", line 479, in set_current_user
    self._current_user = CurrentUser().fetch()  # type: ignore
                         ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cytomine/models/model.py", line 43, in fetch
    return Cytomine.get_instance().get_model(self, self.query_parameters)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cytomine/cytomine.py", line 582, in get_model
    response = self._get(model.uri(), query_parameters)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cytomine/cytomine.py", line 552, in _get
    return self._session.get(
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cachecontrol/adapter.py", line 76, in send
    resp = super().send(request, stream, timeout, verify, cert, proxies)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/adapters.py", line 696, in send
    return self.build_response(request, resp)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cachecontrol/adapter.py", line 128, in build_response
    response._fp = CallbackFileWrapper(  # type: ignore[assignment]
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cachecontrol/filewrapper.py", line 37, in __init__
    self.__buf = NamedTemporaryFile("rb+", delete=True)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/tempfile.py", line 564, in NamedTemporaryFile
    prefix, suffix, dir, output_type = _sanitize_params(prefix, suffix, dir)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/tempfile.py", line 126, in _sanitize_params
    dir = gettempdir()
          ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/tempfile.py", line 315, in gettempdir
    return _os.fsdecode(_gettempdir())
                        ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/tempfile.py", line 308, in _gettempdir
    tempdir = _get_default_tempdir()
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/tempfile.py", line 223, in _get_default_tempdir
    raise FileNotFoundError(_errno.ENOENT,
FileNotFoundError: [Errno 2] No usable temporary directory found in ['/tmp', '/var/tmp', '/usr/tmp', '/app']
```