### PR TITLE
fix(helm): app engine storage

### DIFF
--- a/helm/charts/cytomine/templates/app-engine/app-engine.yaml
+++ b/helm/charts/cytomine/templates/app-engine/app-engine.yaml
@@ -19,6 +19,10 @@ spec:
       securityContext:
       {{- include "cytomine.podSecurityContext" . | nindent 8 }}
       volumes:
+        {{ if not .Values.app_engine.storage.storageClassName -}}
+        - name: app-engine-storage
+          emptyDir: {}
+        {{ end }}
         - name: temp
           emptyDir: {}
       containers:
@@ -45,7 +49,21 @@ spec:
               name: app-engine
               key: token
         volumeMounts:
+          - name: app-engine-storage
+            mountPath: /data
           - name: temp
             mountPath: /tmp
       serviceAccountName: app-engine
       automountServiceAccountToken: true
+  {{ if .Values.app_engine.storage.storageClassName -}}
+  volumeClaimTemplates:
+    - metadata:
+        name: app-engine-storage
+      spec:
+        storageClassName: {{ .Values.app_engine.storage.storageClassName }}
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.app_engine.storage.size }}
+  {{ end }}

--- a/helm/charts/cytomine/values.yaml
+++ b/helm/charts/cytomine/values.yaml
@@ -223,6 +223,9 @@ cbir:
 
 app_engine:
   port: 8080
+  storage:
+    size: 5Gi
+    storageClassName: null
   tasks_namespace:
 
 sam:


### PR DESCRIPTION
#526 

The app engine needs the `/data` folder to be writeable:

```
2026-01-13T12:44:17.274Z  INFO 1 --- [nio-8080-exec-3] b.c.a.controllers.TaskController         : tasks/{namespace}/{version}/runs POST
2026-01-13T12:44:17.275Z  INFO 1 --- [nio-8080-exec-3] b.c.appengine.services.TaskService       : tasks/{namespace}/{version}/runs: creating run...
2026-01-13T12:44:17.275Z  INFO 1 --- [nio-8080-exec-3] b.c.appengine.services.TaskService       : tasks/{namespace}/{version}/runs: retrieving associated task...
2026-01-13T12:44:17.298Z  INFO 1 --- [nio-8080-exec-3] b.c.appengine.services.TaskService       : tasks/{namespace}/{version}/runs: retrieved task...
2026-01-13T12:44:17.303Z ERROR 1 --- [nio-8080-exec-3] b.c.appengine.services.TaskService       : tasks/{namespace}/{version}/runs: failed to create storage [Failed to create storage task-run-inputs-8daf348c-4d03-45a5-bb0e-d58bfa4149ef: /data: Read-only file system]
2026-01-13T12:44:17.305Z  INFO 1 --- [nio-8080-exec-3] c.a.e.h.ProvisionTaskApiExceptionHandler : bad request 404 error [be.cytomine.appengine.exceptions.FileStorageException: Failed to create storage task-run-inputs-8daf348c-4d03-45a5-bb0e-d58bfa4149ef: /data: Read-only file system]
```