### PR TITLE
fix: thumbnail display for geometry

### DIFF
--- a/web-ui/src/components/annotations/SelectableAnnotation.vue
+++ b/web-ui/src/components/annotations/SelectableAnnotation.vue
@@ -10,6 +10,7 @@
       :showDetails="false"
       :size="85"
       :users="users"
+      color="000000"
     />
   </div>
 </template>


### PR DESCRIPTION
Little quality of life improvement to render the annotation in the thumbnail:

Going from

<img width="1920" height="1080" alt="Screenshot from 2026-01-16 10-25-21" src="https://github.com/user-attachments/assets/a65e9f07-3dec-4db1-b1e8-242ad1f4f3ee" />

To

<img width="1920" height="1080" alt="Screenshot from 2026-01-16 10-25-37" src="https://github.com/user-attachments/assets/9e9661ed-8e4f-49f6-8043-8e46c4033e7b" />
