### PR TITLE
fix(pims): DICOM metadata parsing

### DIFF
--- a/pims/plugins/pims-plugin-format-dicom/pims_plugin_format_dicom/dicom.py
+++ b/pims/plugins/pims-plugin-format-dicom/pims_plugin_format_dicom/dicom.py
@@ -27,13 +27,16 @@ from pims.utils.dtypes import np_dtype
 from pims.utils.types import parse_float
 
 
+EXCLUDED_TAGS = [
+    "ICCProfile",
+]
+
+
 def sanitize(value):
     if isinstance(value, DSfloat):
         return float(value)
     if isinstance(value, MultiValue):
         return [sanitize(v) for v in value]
-    if isinstance(value, dict):
-        return {k: sanitize(v) for k, v in value.items()}
     return value
 
 
@@ -180,6 +183,9 @@ class WSIDicomParser(AbstractParser):
                 tag = data_element.tag
                 name = f"{tag.group:04x}_{tag.element:04x}"  # noqa
             name = name.replace(' ', '')
+
+            if name in EXCLUDED_TAGS:
+                continue
 
             value = sanitize(data_element.value)
             store.set(name, value, namespace="DICOM")


### PR DESCRIPTION
Addresses #499 

- The DICOM tags are using the pydicom custom types. Therefore, if a list of `DSFloat` is included, pims fails to parse that list and throws an exception. The solution was to cast into `float` type.
- The [`ICCProfile`](https://dicom.innolitics.com/ciods/rt-dose/image-pixel/00282000) tag in DICOM is an optional tag and its value is a file containing color data. This file can become quite large and the metadata are sent as a json which is not the recommended way for sending this file. It is not mandatory, therefore I skip this tag if it exists