### PR TITLE
chore: iam health checks

### DIFF
--- a/helm/charts/cytomine/templates/iam/iam.yaml
+++ b/helm/charts/cytomine/templates/iam/iam.yaml
@@ -83,6 +83,7 @@ spec:
         command:
         - "/opt/keycloak/bin/kc.sh"
         - "start"
+        # Uncomment next line to print debug logs
         # - "--log-level=DEBUG"
         envFrom:
         - configMapRef:


### PR DESCRIPTION
Locally KC frequently ends up in unknown status. 