### PR TITLE
fix(app-engine): task output response

### DIFF
--- a/app-engine/src/main/java/be/cytomine/appengine/dto/inputs/task/TaskOutput.java
+++ b/app-engine/src/main/java/be/cytomine/appengine/dto/inputs/task/TaskOutput.java
@@ -1,25 +1,11 @@
 package be.cytomine.appengine.dto.inputs.task;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class TaskOutput {
-    private String id;
-
-    private String name;
-
-    @JsonProperty(value = "display_name")
-    private String displayName;
-
-    private String description;
-
-    private boolean optional;
-
-    private TaskParameterType type;
-
-    @JsonProperty(value = "derived_from")
-    private String derivedFrom;
-}
+public record TaskOutput(
+    String id,
+    String name,
+    String displayName,
+    String description,
+    boolean optional,
+    TaskParameterType type,
+    String derivedFrom
+) {}

--- a/core/src/main/java/be/cytomine/dto/appengine/task/TaskRunOutputResponse.java
+++ b/core/src/main/java/be/cytomine/dto/appengine/task/TaskRunOutputResponse.java
@@ -1,10 +1,7 @@
 package be.cytomine.dto.appengine.task;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import be.cytomine.dto.appengine.task.type.TaskParameterType;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public record TaskRunOutputResponse(
     String id,
     String name,

--- a/core/src/test/java/be/cytomine/controller/appengine/TaskRunResourceTests.java
+++ b/core/src/test/java/be/cytomine/controller/appengine/TaskRunResourceTests.java
@@ -107,11 +107,11 @@ public class TaskRunResourceTests {
         mockResponseMap = Map.of(
             "id", taskRun.getTaskRunId().toString(),
             "name", "test name",
-            "display_name", "test display name",
+            "displayName", "test display name",
             "description", "test description",
             "optional", false,
             "type", Map.of("id", "string"),
-            "derived_from", ""
+            "derivedFrom", ""
         );
 
         mockResponse = objectMapper.writeValueAsString(List.of(mockResponseMap));


### PR DESCRIPTION
while working on #528, the output is not correctly mapped