### PR TITLE
fix(repository): add missing env variables

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -231,6 +231,7 @@ services:
       POSTGIS_PASS: password
       POSTGIS_PORT: 5432
       POSTGIS_USER: docker
+      REPOSITORY_URL: http://repository:8081
       STORAGE_PATH: /data/images
     networks:
       host_network:
@@ -276,6 +277,8 @@ services:
     restart: unless-stopped
     ports:
       - 8081:8081
+    environment:
+      POSTGIS_HOST: postgis
     networks:
       host_network:
         ipv4_address: 172.16.238.18


### PR DESCRIPTION
`core` service is missing `REPOSITORY_URL` env variable

```
core-1  | Caused by: org.springframework.util.PlaceholderResolutionException: Could not resolve placeholder 'REPOSITORY_URL' in value "${REPOSITORY_URL}" <-- "${application.repositoryURL}"
core-1  | 	at org.springframework.util.PlaceholderResolutionException.withValue(PlaceholderResolutionException.java:81)
core-1  | 	at org.springframework.util.PlaceholderParser$ParsedValue.resolve(PlaceholderParser.java:423)
core-1  | 	at org.springframework.util.PlaceholderParser.replacePlaceholders(PlaceholderParser.java:128)
core-1  | 	at org.springframework.util.PropertyPlaceholderHelper.parseStringValue(PropertyPlaceholderHelper.java:118)
core-1  | 	at org.springframework.util.PropertyPlaceholderHelper.replacePlaceholders(PropertyPlaceholderHelper.java:114)
core-1  | 	at org.springframework.core.env.AbstractPropertyResolver.doResolvePlaceholders(AbstractPropertyResolver.java:293)
core-1  | 	at org.springframework.core.env.AbstractPropertyResolver.resolveRequiredPlaceholders(AbstractPropertyResolver.java:264)
core-1  | 	at org.springframework.context.support.PropertySourcesPlaceholderConfigurer.lambda$processProperties$0(PropertySourcesPlaceholderConfigurer.java:186)
core-1  | 	at org.springframework.beans.factory.support.AbstractBeanFactory.resolveEmbeddedValue(AbstractBeanFactory.java:971)
core-1  | 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1657)
core-1  | 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1635)
core-1  | 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.resolveFieldValue(AutowiredAnnotationBeanPostProcessor.java:785)
core-1  | 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:768)
core-1  | 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:146)
core-1  | 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessProperties(AutowiredAnnotationBeanPostProcessor.java:509)
core-1  | 	... 47 common frames omitted
```

And `repository` service is missing `POSTGIS_HOST` env variable: 

```
repository-1  | 2026-03-13T08:32:57.398Z  INFO 1 --- [           main] com.zaxxer.hikari.HikariDataSource       : Hikari - Starting...
repository-1  | 2026-03-13T08:32:58.402Z  WARN 1 --- [           main] org.hibernate.orm.jdbc.error             : HHH000247: ErrorCode: 0, SQLState: 08001
repository-1  | 2026-03-13T08:32:58.402Z  WARN 1 --- [           main] org.hibernate.orm.jdbc.error             : Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
repository-1  | 2026-03-13T08:32:58.404Z  WARN 1 --- [           main] org.hibernate.orm.jdbc                   : HHH100046: Could not obtain connection to query JDBC database metadata
repository-1  | 
repository-1  | org.hibernate.exception.JDBCConnectionException: Unable to obtain isolated JDBC connection [Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.] [n/a]
```
