### PR TITLE
chore: make BasicInstanceBuilder non-static

### DIFF
--- a/core/src/test/java/be/cytomine/BasicInstanceBuilder.java
+++ b/core/src/test/java/be/cytomine/BasicInstanceBuilder.java
@@ -2,7 +2,6 @@ package be.cytomine;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import java.util.UUID;
 
 import jakarta.persistence.EntityManager;
@@ -94,19 +93,19 @@ public class BasicInstanceBuilder {
 
     ApplicationBootstrap applicationBootstrap;
 
-    private static User aUser;
-    private static User anAdmin;
-    private static User aGuest;
+    private User aUser;
+    private User anAdmin;
+    private User aGuest;
 
     public BasicInstanceBuilder(
-            EntityManager em,
-            TransactionTemplate transactionTemplate,
-            UserRepository userRepository,
-            PermissionService permissionService,
-            SecRoleRepository secRoleRepository,
-            MimeRepository mimeRepository,
-            ApplicationBootstrap applicationBootstrap) {
-        if (secRoleRepository.count()==0) {
+        EntityManager em,
+        TransactionTemplate transactionTemplate,
+        UserRepository userRepository,
+        PermissionService permissionService,
+        SecRoleRepository secRoleRepository,
+        MimeRepository mimeRepository,
+        ApplicationBootstrap applicationBootstrap) {
+        if (secRoleRepository.count() == 0) {
             applicationBootstrap.init();
         }
         this.em = em;
@@ -120,9 +119,9 @@ public class BasicInstanceBuilder {
             @Override
             protected void doInTransactionWithoutResult(TransactionStatus status) {
                 aUser = userRepository.findByUsernameLikeIgnoreCase("user")
-                        .orElseGet(() -> given_default_user());
+                            .orElseGet(() -> given_default_user());
                 anAdmin = userRepository.findByUsernameLikeIgnoreCase("admin")
-                        .orElseGet(() -> given_default_admin());
+                              .orElseGet(() -> given_default_admin());
             }
         });
     }
@@ -185,13 +184,14 @@ public class BasicInstanceBuilder {
         return user;
     }
 
-    public void addRole(User user, String authority) {
-        SecUserSecRole secSecUserSecRole = new SecUserSecRole();
-        secSecUserSecRole.setSecUser(user);
-        secSecUserSecRole.setSecRole(secRoleRepository.findByAuthority(authority).orElseThrow(() -> new ObjectNotFoundException("authority " + authority + " does not exists")));
-        em.persist(secSecUserSecRole);
-        em.flush();
-        em.refresh(user);
+    public static RelationTerm given_a_not_persisted_relation_term(Relation relation, Term term1,
+                                                                   Term term2) {
+        RelationTerm relationTerm = new RelationTerm();
+        relationTerm.setRelation(relation);
+        relationTerm.setTerm1(term1);
+        relationTerm.setTerm2(term2);
+
+        return relationTerm;
     }
 
     public User given_superadmin() {
@@ -209,7 +209,19 @@ public class BasicInstanceBuilder {
         return user;
     }
 
-    public ImageFilterProject given_a_not_persisted_image_filter_project(ImageFilter imageFilter, Project project) {
+    public void addRole(User user, String authority) {
+        SecUserSecRole secSecUserSecRole = new SecUserSecRole();
+        secSecUserSecRole.setSecUser(user);
+        secSecUserSecRole.setSecRole(secRoleRepository.findByAuthority(authority)
+                                         .orElseThrow(() -> new ObjectNotFoundException(
+                                             "authority " + authority + " does not exists")));
+        em.persist(secSecUserSecRole);
+        em.flush();
+        em.refresh(user);
+    }
+
+    public ImageFilterProject given_a_not_persisted_image_filter_project(ImageFilter imageFilter,
+                                                                         Project project) {
         ImageFilterProject imageFilterProject = new ImageFilterProject();
         imageFilterProject.setImageFilter(imageFilter);
         imageFilterProject.setProject(project);
@@ -217,11 +229,8 @@ public class BasicInstanceBuilder {
     }
 
     public ImageFilterProject given_a_image_filter_project() {
-        return persistAndReturn(given_a_not_persisted_image_filter_project(given_a_image_filter(), given_a_project()));
-    }
-
-    public ImageFilterProject given_a_image_filter_project(ImageFilter imageFilter, Project project) {
-        return persistAndReturn(given_a_not_persisted_image_filter_project(imageFilter, project));
+        return persistAndReturn(
+            given_a_not_persisted_image_filter_project(given_a_image_filter(), given_a_project()));
     }
 
     public ImageFilter given_a_not_persisted_image_filter() {
@@ -230,6 +239,7 @@ public class BasicInstanceBuilder {
         imageFilter.setMethod(randomString());
         return imageFilter;
     }
+
     public ImageFilter given_a_image_filter() {
         return persistAndReturn(given_a_not_persisted_image_filter());
     }
@@ -250,8 +260,9 @@ public class BasicInstanceBuilder {
         return term;
     }
 
-    public Relation given_a_relation() {
-        return (Relation)em.createQuery("SELECT relation FROM Relation relation WHERE relation.name LIKE 'parent'").getResultList().get(0);
+    public ImageFilterProject given_a_image_filter_project(ImageFilter imageFilter,
+                                                           Project project) {
+        return persistAndReturn(given_a_not_persisted_image_filter_project(imageFilter, project));
     }
 
     public RelationTerm given_a_relation_term() {
@@ -267,20 +278,18 @@ public class BasicInstanceBuilder {
         return persistAndReturn(given_a_not_persisted_relation_term(relation, term1, term2));
     }
 
-    public static RelationTerm given_a_not_persisted_relation_term(Relation relation, Term term1, Term term2) {
-        RelationTerm relationTerm = new RelationTerm();
-        relationTerm.setRelation(relation);
-        relationTerm.setTerm1(term1);
-        relationTerm.setTerm2(term2);
-
-        return relationTerm;
+    public Relation given_a_relation() {
+        return (Relation) em.createQuery(
+                "SELECT relation FROM Relation relation WHERE relation.name LIKE 'parent'")
+                              .getResultList()
+                              .get(0);
     }
 
     public Ontology given_an_ontology() {
         return persistAndReturn(given_a_not_persisted_ontology());
     }
 
-    public static Ontology given_a_not_persisted_ontology() {
+    public Ontology given_a_not_persisted_ontology() {
         Ontology ontology = new Ontology();
         ontology.setName(randomString());
         ontology.setUser(aUser);
@@ -298,7 +307,7 @@ public class BasicInstanceBuilder {
     }
 
     public Project given_a_project_with_ontology(Ontology ontology) {
-        Project project =  given_a_not_persisted_project();
+        Project project = given_a_not_persisted_project();
         project.setOntology(ontology);
         return persistAndReturn(project);
     }
@@ -324,7 +333,8 @@ public class BasicInstanceBuilder {
     }
 
     public void addUserToOntology(Ontology ontology, String username) {
-        permissionService.addPermission(ontology, username, ADMINISTRATION, this.given_superadmin());
+        permissionService.addPermission(ontology, username, ADMINISTRATION,
+            this.given_superadmin());
     }
 
     public void addUserToStorage(Storage storage, String username, Permission permission) {
@@ -371,7 +381,8 @@ public class BasicInstanceBuilder {
         Storage storage = given_a_not_persisted_storage();
         storage.setUser(user);
         storage = persistAndReturn(storage);
-        permissionService.addPermission(storage, storage.getUser().getUsername(), ADMINISTRATION, storage.getUser());
+        permissionService.addPermission(storage, storage.getUser().getUsername(), ADMINISTRATION,
+            storage.getUser());
         return storage;
     }
 
@@ -419,7 +430,8 @@ public class BasicInstanceBuilder {
         return given_a_not_persisted_image_instance(given_an_abstract_image(), given_a_project());
     }
 
-    public ImageInstance given_a_not_persisted_image_instance(AbstractImage abstractImage, Project project) {
+    public ImageInstance given_a_not_persisted_image_instance(AbstractImage abstractImage,
+                                                              Project project) {
         ImageInstance image = new ImageInstance();
         image.setBaseImage(abstractImage);
         image.setProject(project);
@@ -433,7 +445,8 @@ public class BasicInstanceBuilder {
     }
 
     public ImageInstance given_an_image_instance() {
-        ImageInstance imageInstance = given_an_image_instance(given_an_abstract_image(), given_a_project());
+        ImageInstance imageInstance =
+            given_an_image_instance(given_an_abstract_image(), given_a_project());
         return persistAndReturn(imageInstance);
     }
 
@@ -446,7 +459,8 @@ public class BasicInstanceBuilder {
     }
 
     public AbstractSlice given_an_abstract_slice(AbstractImage abstractImage, int c, int z, int t) {
-        AbstractSlice slice = given_a_not_persisted_abstract_slice(abstractImage, abstractImage.getUploadedFile());
+        AbstractSlice slice =
+            given_a_not_persisted_abstract_slice(abstractImage, abstractImage.getUploadedFile());
         slice.setMime(given_a_mime("openslide/mrxs"));
         slice.setChannel(c);
         slice.setZStack(z);
@@ -454,15 +468,18 @@ public class BasicInstanceBuilder {
         return persistAndReturn(slice);
     }
 
-    public AbstractSlice given_an_abstract_slice(AbstractImage abstractImage, UploadedFile uploadedFile) {
+    public AbstractSlice given_an_abstract_slice(AbstractImage abstractImage,
+                                                 UploadedFile uploadedFile) {
         return persistAndReturn(given_a_not_persisted_abstract_slice(abstractImage, uploadedFile));
     }
 
     public AbstractSlice given_a_not_persisted_abstract_slice() {
-        return given_a_not_persisted_abstract_slice(given_an_abstract_image(), given_a_uploaded_file());
+        return given_a_not_persisted_abstract_slice(given_an_abstract_image(),
+            given_a_uploaded_file());
     }
 
-    public AbstractSlice given_a_not_persisted_abstract_slice(AbstractImage abstractImage, UploadedFile uploadedFile) {
+    public AbstractSlice given_a_not_persisted_abstract_slice(AbstractImage abstractImage,
+                                                              UploadedFile uploadedFile) {
         AbstractSlice slice = new AbstractSlice();
         slice.setImage(abstractImage);
         slice.setUploadedFile(uploadedFile);
@@ -478,25 +495,31 @@ public class BasicInstanceBuilder {
     }
 
     public SliceInstance given_a_slice_instance(ImageInstance imageInstance, int c, int z, int t) {
-        AbstractSlice abstractSlice = given_an_abstract_slice(imageInstance.getBaseImage(), c, z, t);
+        AbstractSlice abstractSlice =
+            given_an_abstract_slice(imageInstance.getBaseImage(), c, z, t);
         return persistAndReturn(given_a_not_persisted_slice_instance(imageInstance, abstractSlice));
     }
 
-    public SliceInstance given_a_slice_instance(ImageInstance imageInstance, AbstractSlice abstractSlice) {
+    public SliceInstance given_a_slice_instance(ImageInstance imageInstance,
+                                                AbstractSlice abstractSlice) {
         return persistAndReturn(given_a_not_persisted_slice_instance(imageInstance, abstractSlice));
     }
 
     public SliceInstance given_a_not_persisted_slice_instance() {
-        return given_a_not_persisted_slice_instance(given_an_image_instance(), given_an_abstract_slice());
+        return given_a_not_persisted_slice_instance(given_an_image_instance(),
+            given_an_abstract_slice());
     }
 
     public SliceInstance given_a_slice_instance(Project project) {
         AbstractImage image = given_an_abstract_image();
-        SliceInstance sliceInstance = given_a_slice_instance(given_an_image_instance(image, project), given_an_abstract_slice(image, 0,0,0));
+        SliceInstance sliceInstance =
+            given_a_slice_instance(given_an_image_instance(image, project),
+                given_an_abstract_slice(image, 0, 0, 0));
         return persistAndReturn(sliceInstance);
     }
 
-    public SliceInstance given_a_not_persisted_slice_instance(ImageInstance imageInstance, AbstractSlice abstractSlice) {
+    public SliceInstance given_a_not_persisted_slice_instance(ImageInstance imageInstance,
+                                                              AbstractSlice abstractSlice) {
         SliceInstance slice = new SliceInstance();
         slice.setImage(imageInstance);
         slice.setProject(imageInstance.getProject());
@@ -518,7 +541,8 @@ public class BasicInstanceBuilder {
     }
 
     public Mime given_a_mime(String mimeType) {
-        return mimeRepository.findByMimeType(mimeType).orElseThrow(() -> new ObjectNotFoundException("MimeType", mimeType));
+        return mimeRepository.findByMimeType(mimeType)
+                   .orElseThrow(() -> new ObjectNotFoundException("MimeType", mimeType));
     }
 
     public NestedImageInstance given_a_nested_image_instance() {
@@ -545,7 +569,8 @@ public class BasicInstanceBuilder {
         return persistAndReturn(given_a_not_persisted_property(cytomineDomain, key, value));
     }
 
-    public Property given_a_not_persisted_property(CytomineDomain cytomineDomain, String key, String value) {
+    public Property given_a_not_persisted_property(CytomineDomain cytomineDomain, String key,
+                                                   String value) {
         Property property = new Property();
         property.setDomain(cytomineDomain);
         property.setKey(key);
@@ -572,7 +597,8 @@ public class BasicInstanceBuilder {
         UserAnnotation annotation = new UserAnnotation();
         annotation.setUser(given_superadmin());
         try {
-            annotation.setLocation(new WKTReader().read("POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))"));
+            annotation.setLocation(
+                new WKTReader().read("POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))"));
         } catch (ParseException ignored) {
 
         }
@@ -582,11 +608,12 @@ public class BasicInstanceBuilder {
         return annotation;
     }
 
-        public UserAnnotation given_a_not_persisted_guest_annotation() {
+    public UserAnnotation given_a_not_persisted_guest_annotation() {
         UserAnnotation annotation = new UserAnnotation();
         annotation.setUser(given_a_guest());
         try {
-            annotation.setLocation(new WKTReader().read("POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))"));
+            annotation.setLocation(
+                new WKTReader().read("POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))"));
         } catch (ParseException ignored) {
 
         }
@@ -617,7 +644,8 @@ public class BasicInstanceBuilder {
         UserAnnotation annotation = new UserAnnotation();
         annotation.setUser(given_superadmin());
         try {
-            annotation.setLocation(new WKTReader().read("POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))"));
+            annotation.setLocation(
+                new WKTReader().read("POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))"));
         } catch (ParseException ignored) {
 
         }
@@ -644,13 +672,14 @@ public class BasicInstanceBuilder {
         return persistAndReturn(given_a_not_persisted_user_annotation());
     }
 
-    public UserAnnotation given_a_user_annotation(SliceInstance sliceInstance, String location, User user, Term term) throws ParseException {
+    public UserAnnotation given_a_user_annotation(SliceInstance sliceInstance, String location,
+                                                  User user, Term term) throws ParseException {
         UserAnnotation annotation = given_a_not_persisted_user_annotation(sliceInstance);
         annotation.setLocation(new WKTReader().read(location));
         annotation.setUser(user);
         persistAndReturn(annotation);
 
-        if (term!=null) {
+        if (term != null) {
             AnnotationTerm annotationTerm = new AnnotationTerm();
             annotationTerm.setUserAnnotation(annotation);
             annotationTerm.setUser(user);
@@ -662,10 +691,12 @@ public class BasicInstanceBuilder {
     }
 
     public AnnotationTerm given_a_not_persisted_annotation_term(UserAnnotation annotation) {
-        return given_a_not_persisted_annotation_term(annotation, this.given_a_term(annotation.getProject().getOntology()));
+        return given_a_not_persisted_annotation_term(annotation,
+            this.given_a_term(annotation.getProject().getOntology()));
     }
 
-    public AnnotationTerm given_a_not_persisted_annotation_term(UserAnnotation annotation, Term term) {
+    public AnnotationTerm given_a_not_persisted_annotation_term(UserAnnotation annotation,
+                                                                Term term) {
         AnnotationTerm annotationTerm = new AnnotationTerm();
         annotationTerm.setTerm(term);
         annotationTerm.setUser(this.given_superadmin());
@@ -678,19 +709,22 @@ public class BasicInstanceBuilder {
     }
 
     public AnnotationTerm given_an_annotation_term(UserAnnotation annotation) {
-        return persistAndReturn(given_a_not_persisted_annotation_term(annotation, this.given_a_term(annotation.getProject().getOntology())));
+        return persistAndReturn(given_a_not_persisted_annotation_term(annotation,
+            this.given_a_term(annotation.getProject().getOntology())));
     }
 
     public AnnotationTerm given_an_annotation_term() {
         UserAnnotation annotation = given_a_user_annotation();
-        return persistAndReturn(given_a_not_persisted_annotation_term(annotation, this.given_a_term(annotation.getProject().getOntology())));
+        return persistAndReturn(given_a_not_persisted_annotation_term(annotation,
+            this.given_a_term(annotation.getProject().getOntology())));
     }
 
     public ReviewedAnnotation given_a_not_persisted_reviewed_annotation() {
         ReviewedAnnotation annotation = new ReviewedAnnotation();
         annotation.setUser(given_superadmin());
         try {
-            annotation.setLocation(new WKTReader().read("POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))"));
+            annotation.setLocation(
+                new WKTReader().read("POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))"));
         } catch (ParseException ignored) {
 
         }
@@ -723,17 +757,20 @@ public class BasicInstanceBuilder {
     }
 
     public ReviewedAnnotation given_a_reviewed_annotation(Project project) throws ParseException {
-        SliceInstance sliceInstance = given_a_slice_instance(given_an_image_instance(project), given_an_abstract_slice());
+        SliceInstance sliceInstance =
+            given_a_slice_instance(given_an_image_instance(project), given_an_abstract_slice());
         return given_a_reviewed_annotation(
-                sliceInstance,
-                "POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))",
-                given_superadmin(),
-                given_a_term(project.getOntology()));
+            sliceInstance,
+            "POLYGON ((1983 2168, 2107 2160, 2047 2074, 1983 2168))",
+            given_superadmin(),
+            given_a_term(project.getOntology()));
     }
 
-    public ReviewedAnnotation given_a_reviewed_annotation(SliceInstance sliceInstance, String location, User user, Term term) throws ParseException {
+    public ReviewedAnnotation given_a_reviewed_annotation(SliceInstance sliceInstance,
+                                                          String location, User user, Term term)
+        throws ParseException {
         UserAnnotation userAnnotation =
-                given_a_user_annotation(sliceInstance, location, user, term);
+            given_a_user_annotation(sliceInstance, location, user, term);
 
         ReviewedAnnotation annotation = new ReviewedAnnotation();
         annotation.setImage(sliceInstance.getImage());
@@ -746,7 +783,7 @@ public class BasicInstanceBuilder {
         annotation.setStatus(0);
         persistAndReturn(annotation);
 
-        if (term!=null) {
+        if (term != null) {
             AnnotationTerm annotationTerm = new AnnotationTerm();
             annotationTerm.setUserAnnotation(userAnnotation);
             annotationTerm.setUser(user);
@@ -764,7 +801,8 @@ public class BasicInstanceBuilder {
     public SharedAnnotation given_a_not_persisted_shared_annotation() {
         SharedAnnotation sharedAnnotation = new SharedAnnotation();
         sharedAnnotation.setAnnotation(given_a_user_annotation());
-        sharedAnnotation.setComment("Rech. proj. pr proj. priv. Self Dem. Brt. Poss. S'adr. à l'hô. Mart");
+        sharedAnnotation.setComment(
+            "Rech. proj. pr proj. priv. Self Dem. Brt. Poss. S'adr. à l'hô. Mart");
         sharedAnnotation.setSender(given_superadmin());
         sharedAnnotation.setReceivers(List.of(given_superadmin()));
         return sharedAnnotation;
@@ -773,6 +811,7 @@ public class BasicInstanceBuilder {
     public SharedAnnotation given_a_shared_annotation() {
         return persistAndReturn(given_a_not_persisted_shared_annotation());
     }
+
     public SharedAnnotation given_a_shared_annotation(AnnotationDomain annotationDomain) {
         SharedAnnotation sharedAnnotation = given_a_not_persisted_shared_annotation();
         sharedAnnotation.setAnnotation(annotationDomain);
@@ -873,7 +912,8 @@ public class BasicInstanceBuilder {
         return persistAndReturn(given_a_not_persisted_tag_association(tag, domain));
     }
 
-    public TagDomainAssociation given_a_not_persisted_tag_association(Tag tag, CytomineDomain domain) {
+    public TagDomainAssociation given_a_not_persisted_tag_association(Tag tag,
+                                                                      CytomineDomain domain) {
         TagDomainAssociation tagDomainAssociation = new TagDomainAssociation();
         tagDomainAssociation.setTag(tag);
         tagDomainAssociation.setDomain(domain);
@@ -881,18 +921,22 @@ public class BasicInstanceBuilder {
     }
 
     public ProjectRepresentativeUser given_a_project_representative_user() {
-        return persistAndReturn(given_a_not_persisted_project_representative_user(given_a_project(), given_superadmin()));
+        return persistAndReturn(given_a_not_persisted_project_representative_user(given_a_project(),
+            given_superadmin()));
     }
 
-    public ProjectRepresentativeUser given_a_project_representative_user(Project project, User user) {
+    public ProjectRepresentativeUser given_a_project_representative_user(Project project,
+                                                                         User user) {
         return persistAndReturn(given_a_not_persisted_project_representative_user(project, user));
     }
 
     public ProjectRepresentativeUser given_a_not_persisted_project_representative_user() {
-        return given_a_not_persisted_project_representative_user(given_a_project(), given_superadmin());
+        return given_a_not_persisted_project_representative_user(given_a_project(),
+            given_superadmin());
     }
 
-    public ProjectRepresentativeUser given_a_not_persisted_project_representative_user(Project project, User user) {
+    public ProjectRepresentativeUser given_a_not_persisted_project_representative_user(
+        Project project, User user) {
         addUserToProject(project, user.getUsername());
         ProjectRepresentativeUser projectRepresentativeUser = new ProjectRepresentativeUser();
         projectRepresentativeUser.setUser(user);
@@ -902,7 +946,8 @@ public class BasicInstanceBuilder {
 
 
     public ProjectDefaultLayer given_a_project_default_layer() {
-        return persistAndReturn(given_a_not_persisted_project_default_layer(given_a_project(), given_superadmin()));
+        return persistAndReturn(
+            given_a_not_persisted_project_default_layer(given_a_project(), given_superadmin()));
     }
 
     public ProjectDefaultLayer given_a_project_default_layer(Project project, User user) {
@@ -913,7 +958,8 @@ public class BasicInstanceBuilder {
         return given_a_not_persisted_project_default_layer(given_a_project(), given_superadmin());
     }
 
-    public ProjectDefaultLayer given_a_not_persisted_project_default_layer(Project project, User user) {
+    public ProjectDefaultLayer given_a_not_persisted_project_default_layer(Project project,
+                                                                           User user) {
         addUserToProject(project, user.getUsername());
         ProjectDefaultLayer projectDefaultLayer = new ProjectDefaultLayer();
         projectDefaultLayer.setUser(user);
@@ -923,11 +969,13 @@ public class BasicInstanceBuilder {
     }
 
     public SecUserSecRole given_a_user_role() {
-        return persistAndReturn(given_a_not_persisted_user_role( given_a_guest(), secRoleRepository.findByAuthority(ROLE_USER).get()));
+        return persistAndReturn(given_a_not_persisted_user_role(given_a_guest(),
+            secRoleRepository.findByAuthority(ROLE_USER).get()));
     }
 
     public SecUserSecRole given_a_user_role(User user) {
-        return persistAndReturn(given_a_not_persisted_user_role(user, secRoleRepository.findByAuthority(ROLE_USER).get()));
+        return persistAndReturn(given_a_not_persisted_user_role(user,
+            secRoleRepository.findByAuthority(ROLE_USER).get()));
     }
 
     public SecUserSecRole given_a_user_role(User user, SecRole secRole) {
@@ -935,7 +983,8 @@ public class BasicInstanceBuilder {
     }
 
     public SecUserSecRole given_a_not_persisted_user_role(User user, String authority) {
-        return given_a_not_persisted_user_role(user, secRoleRepository.findByAuthority(authority).get());
+        return given_a_not_persisted_user_role(user,
+            secRoleRepository.findByAuthority(authority).get());
     }
 
     public SecUserSecRole given_a_not_persisted_user_role(User secUser, SecRole secRole) {
@@ -972,7 +1021,8 @@ public class BasicInstanceBuilder {
         return given_a_not_persisted_imagegroup_imageinstance(group, image);
     }
 
-    public ImageGroupImageInstance given_a_not_persisted_imagegroup_imageinstance(ImageGroup group, ImageInstance image) {
+    public ImageGroupImageInstance given_a_not_persisted_imagegroup_imageinstance(ImageGroup group,
+                                                                                  ImageInstance image) {
         ImageGroupImageInstance igii = new ImageGroupImageInstance();
         igii.setGroup(group);
         igii.setImage(image);
@@ -987,14 +1037,16 @@ public class BasicInstanceBuilder {
         return persistAndReturn(igii);
     }
 
-    public ImageGroupImageInstance given_an_imagegroup_imageinstance(ImageGroup group, ImageInstance image) {
+    public ImageGroupImageInstance given_an_imagegroup_imageinstance(ImageGroup group,
+                                                                     ImageInstance image) {
         ImageGroupImageInstance igii = given_a_not_persisted_imagegroup_imageinstance();
         igii.setGroup(group);
         igii.setImage(image);
         return persistAndReturn(igii);
     }
 
-    public AnnotationGroup given_a_not_persisted_annotation_group(Project project, ImageGroup imageGroup) {
+    public AnnotationGroup given_a_not_persisted_annotation_group(Project project,
+                                                                  ImageGroup imageGroup) {
         AnnotationGroup annotationGroup = new AnnotationGroup();
         annotationGroup.setProject(project);
         annotationGroup.setImageGroup(imageGroup);
@@ -1016,7 +1068,7 @@ public class BasicInstanceBuilder {
     }
 
     public AnnotationLink given_a_not_persisted_annotation_link(
-            UserAnnotation annotation, AnnotationGroup annotationGroup, ImageInstance image
+        UserAnnotation annotation, AnnotationGroup annotationGroup, ImageInstance image
     ) {
         AnnotationLink annotationLink = new AnnotationLink();
         annotationLink.setAnnotationClassName(annotation.getClass().getName());
@@ -1031,17 +1083,17 @@ public class BasicInstanceBuilder {
         Project project = given_a_project();
 
         return given_a_not_persisted_annotation_link(
-                given_a_user_annotation(project),
-                given_an_annotation_group(project, given_an_imagegroup(project)),
-                given_an_image_instance(project)
+            given_a_user_annotation(project),
+            given_an_annotation_group(project, given_an_imagegroup(project)),
+            given_an_image_instance(project)
         );
     }
 
     public AnnotationLink given_an_annotation_link(
-            UserAnnotation annotation, AnnotationGroup annotationGroup, ImageInstance image
+        UserAnnotation annotation, AnnotationGroup annotationGroup, ImageInstance image
     ) {
         return persistAndReturn(given_a_not_persisted_annotation_link(
-                annotation, annotationGroup, image
+            annotation, annotationGroup, image
         ));
     }
 
@@ -1050,10 +1102,12 @@ public class BasicInstanceBuilder {
     }
 
     public TaskRun given_a_not_persisted_task_run() {
-        return given_a_not_persisted_task_run(given_a_project(), UUID.randomUUID(), given_an_image_instance());
+        return given_a_not_persisted_task_run(given_a_project(), UUID.randomUUID(),
+            given_an_image_instance());
     }
 
-    public TaskRun given_a_not_persisted_task_run(Project project, UUID taskRunId, ImageInstance image) {
+    public TaskRun given_a_not_persisted_task_run(Project project, UUID taskRunId,
+                                                  ImageInstance image) {
         TaskRun taskRun = new TaskRun();
         taskRun.setProject(project);
         taskRun.setUser(given_superadmin());
@@ -1063,7 +1117,8 @@ public class BasicInstanceBuilder {
     }
 
     public TaskRun given_a_task_run() {
-        return persistAndReturn(given_a_not_persisted_task_run(given_a_project(), UUID.randomUUID(), given_an_image_instance()));
+        return persistAndReturn(given_a_not_persisted_task_run(given_a_project(), UUID.randomUUID(),
+            given_an_image_instance()));
     }
 
     public AnnotationLayer given_a_not_persisted_annotation_layer() {
@@ -1091,7 +1146,8 @@ public class BasicInstanceBuilder {
         return persistAndReturn(given_a_not_persisted_annotation());
     }
 
-    public TaskRunLayer given_a_not_persisted_task_run_layer(AnnotationLayer annotationLayer, TaskRun taskRun, ImageInstance image) {
+    public TaskRunLayer given_a_not_persisted_task_run_layer(AnnotationLayer annotationLayer,
+                                                             TaskRun taskRun, ImageInstance image) {
         TaskRunLayer taskRunLayer = new TaskRunLayer();
         taskRunLayer.setAnnotationLayer(annotationLayer);
         taskRunLayer.setTaskRun(taskRun);
@@ -1100,7 +1156,8 @@ public class BasicInstanceBuilder {
     }
 
     public TaskRunLayer given_a_not_persisted_task_run_layer() {
-        return given_a_not_persisted_task_run_layer(given_a_persisted_annotation_layer(), given_a_task_run(), given_an_image_instance());
+        return given_a_not_persisted_task_run_layer(given_a_persisted_annotation_layer(),
+            given_a_task_run(), given_an_image_instance());
     }
 
     public TaskRunLayer given_a_persisted_task_run_layer() {

--- a/core/src/test/java/be/cytomine/authorization/ontology/OntologyAuthorizationTest.java
+++ b/core/src/test/java/be/cytomine/authorization/ontology/OntologyAuthorizationTest.java
@@ -1,28 +1,23 @@
 package be.cytomine.authorization.ontology;
 
 /*
-* Copyright (c) 2009-2022. Authors: see NOTICE file.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2009-2022. Authors: see NOTICE file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import be.cytomine.BasicInstanceBuilder;
-import be.cytomine.CytomineCoreApplication;
-import be.cytomine.authorization.CRUDAuthorizationTest;
-import be.cytomine.domain.ontology.Ontology;
-import be.cytomine.service.PermissionService;
-import be.cytomine.service.ontology.OntologyService;
-import be.cytomine.service.security.SecurityACLService;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +28,13 @@ import org.springframework.security.acls.model.Permission;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import be.cytomine.BasicInstanceBuilder;
+import be.cytomine.CytomineCoreApplication;
+import be.cytomine.authorization.CRUDAuthorizationTest;
+import be.cytomine.domain.ontology.Ontology;
+import be.cytomine.service.PermissionService;
+import be.cytomine.service.ontology.OntologyService;
+import be.cytomine.service.security.SecurityACLService;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -42,6 +43,8 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @Transactional
 public class OntologyAuthorizationTest extends CRUDAuthorizationTest {
 
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
     private Ontology ontology = null;
 
@@ -74,13 +77,13 @@ public class OntologyAuthorizationTest extends CRUDAuthorizationTest {
 
     @Test
     @WithMockUser(username = USER_ACL_READ)
-    public void user_with_at_least_read_permission_can_list_ontologies(){
+    public void user_with_at_least_read_permission_can_list_ontologies() {
         assertThat(ontologyService.list()).contains(ontology);
     }
 
     @Test
     @WithMockUser(username = USER_NO_ACL)
-    public void user_no_acl_cannot_list_ontologies(){
+    public void user_no_acl_cannot_list_ontologies() {
         assertThat(ontologyService.list()).doesNotContain(ontology);
     }
 
@@ -88,14 +91,15 @@ public class OntologyAuthorizationTest extends CRUDAuthorizationTest {
     @Test
     @WithMockUser(username = USER_NO_ACL)
     public void user_without_permission_add_domain() {
-        expectOK (() -> when_i_add_domain());
+        expectOK(() -> when_i_add_domain());
         // User with no ACL can create an ontology
     }
+
     @Override
     @Test
     @WithMockUser(username = USER_ACL_READ)
     public void user_with_read_permission_add_domain() {
-        expectOK (() -> when_i_add_domain());
+        expectOK(() -> when_i_add_domain());
         // User with READ permission can create another ontology
     }
 
@@ -106,7 +110,7 @@ public class OntologyAuthorizationTest extends CRUDAuthorizationTest {
 
     @Override
     protected void when_i_add_domain() {
-        ontologyService.add(BasicInstanceBuilder.given_a_not_persisted_ontology().toJsonObject());
+        ontologyService.add(basicInstanceBuilder.given_a_not_persisted_ontology().toJsonObject());
     }
 
     @Override

--- a/core/src/test/java/be/cytomine/authorization/ontology/RelationTermAuthorizationTest.java
+++ b/core/src/test/java/be/cytomine/authorization/ontology/RelationTermAuthorizationTest.java
@@ -16,16 +16,8 @@ package be.cytomine.authorization.ontology;
 * limitations under the License.
 */
 
-import be.cytomine.BasicInstanceBuilder;
-import be.cytomine.CytomineCoreApplication;
-import be.cytomine.authorization.CRDAuthorizationTest;
-import be.cytomine.authorization.CRUDAuthorizationTest;
-import be.cytomine.domain.ontology.RelationTerm;
-import be.cytomine.domain.ontology.Term;
-import be.cytomine.service.PermissionService;
-import be.cytomine.service.ontology.RelationTermService;
-import be.cytomine.service.ontology.TermService;
-import be.cytomine.service.security.SecurityACLService;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,12 +28,20 @@ import org.springframework.security.acls.model.Permission;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import be.cytomine.BasicInstanceBuilder;
+import be.cytomine.CytomineCoreApplication;
+import be.cytomine.authorization.CRDAuthorizationTest;
+import be.cytomine.domain.ontology.RelationTerm;
+import be.cytomine.service.PermissionService;
+import be.cytomine.service.ontology.RelationTermService;
+import be.cytomine.service.security.SecurityACLService;
 
 @AutoConfigureMockMvc
 @SpringBootTest(classes = CytomineCoreApplication.class)
 @Transactional
 public class RelationTermAuthorizationTest extends CRDAuthorizationTest {
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
 
     private RelationTerm relationTerm = null;
@@ -98,7 +98,9 @@ public class RelationTermAuthorizationTest extends CRDAuthorizationTest {
     @Override
     protected void when_i_add_domain() {
         relationTermService.add(
-                BasicInstanceBuilder.given_a_not_persisted_relation_term(relationTerm.getRelation(), relationTerm.getTerm1(), builder.given_a_term(relationTerm.getTerm1().getOntology())).toJsonObject()
+            basicInstanceBuilder.given_a_not_persisted_relation_term(relationTerm.getRelation(),
+                relationTerm.getTerm1(),
+                builder.given_a_term(relationTerm.getTerm1().getOntology())).toJsonObject()
         );
     }
 

--- a/core/src/test/java/be/cytomine/authorization/ontology/TermAuthorizationTest.java
+++ b/core/src/test/java/be/cytomine/authorization/ontology/TermAuthorizationTest.java
@@ -16,13 +16,8 @@ package be.cytomine.authorization.ontology;
 * limitations under the License.
 */
 
-import be.cytomine.BasicInstanceBuilder;
-import be.cytomine.CytomineCoreApplication;
-import be.cytomine.authorization.CRUDAuthorizationTest;
-import be.cytomine.domain.ontology.Term;
-import be.cytomine.service.PermissionService;
-import be.cytomine.service.ontology.TermService;
-import be.cytomine.service.security.SecurityACLService;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,20 +28,20 @@ import org.springframework.security.acls.model.Permission;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.persistence.EntityManager;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import be.cytomine.BasicInstanceBuilder;
+import be.cytomine.CytomineCoreApplication;
+import be.cytomine.authorization.CRUDAuthorizationTest;
+import be.cytomine.domain.ontology.Term;
+import be.cytomine.service.PermissionService;
+import be.cytomine.service.ontology.TermService;
+import be.cytomine.service.security.SecurityACLService;
 
 @AutoConfigureMockMvc
 @SpringBootTest(classes = CytomineCoreApplication.class)
 @Transactional
 public class TermAuthorizationTest extends CRUDAuthorizationTest {
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
 
     private Term term = null;
@@ -93,7 +88,8 @@ public class TermAuthorizationTest extends CRUDAuthorizationTest {
 
     @Override
     protected void when_i_add_domain() {
-        termService.add(BasicInstanceBuilder.given_a_not_persisted_term(term.getOntology()).toJsonObject());
+        termService.add(
+            basicInstanceBuilder.given_a_not_persisted_term(term.getOntology()).toJsonObject());
     }
 
     @Override

--- a/core/src/test/java/be/cytomine/authorization/project/ProjectAuthorizationTest.java
+++ b/core/src/test/java/be/cytomine/authorization/project/ProjectAuthorizationTest.java
@@ -1,6 +1,10 @@
 package be.cytomine.authorization.project;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -41,10 +45,15 @@ import be.cytomine.service.project.ProjectRepresentativeUserService;
 import be.cytomine.service.project.ProjectService;
 import be.cytomine.service.search.ProjectSearchExtension;
 
-import static be.cytomine.domain.project.EditingMode.*;
+import static be.cytomine.domain.project.EditingMode.CLASSIC;
+import static be.cytomine.domain.project.EditingMode.READ_ONLY;
+import static be.cytomine.domain.project.EditingMode.RESTRICTED;
 import static be.cytomine.service.middleware.ImageServerService.IMS_API_BASE_PATH;
 import static be.cytomine.service.search.RetrievalService.CBIR_API_BASE_PATH;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.springframework.security.acls.domain.BasePermission.ADMINISTRATION;
 
@@ -52,6 +61,9 @@ import static org.springframework.security.acls.domain.BasePermission.ADMINISTRA
 @SpringBootTest(classes = CytomineCoreApplication.class)
 @Transactional
 public class ProjectAuthorizationTest extends CRUDAuthorizationTest {
+
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     private ProjectMemberService projectMemberService;
@@ -1339,7 +1351,7 @@ public class ProjectAuthorizationTest extends CRUDAuthorizationTest {
 
     @Override
     protected void when_i_add_domain() {
-        projectService.add(BasicInstanceBuilder.given_a_not_persisted_project().toJsonObject());
+        projectService.add(basicInstanceBuilder.given_a_not_persisted_project().toJsonObject());
     }
 
     @Override

--- a/core/src/test/java/be/cytomine/controller/CommandControllerTests.java
+++ b/core/src/test/java/be/cytomine/controller/CommandControllerTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -33,8 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import be.cytomine.BasicInstanceBuilder;
 import be.cytomine.CytomineCoreApplication;
-import be.cytomine.config.MongoTestConfiguration;
 import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
 import be.cytomine.domain.command.Command;
 import be.cytomine.domain.command.DeleteCommand;
 import be.cytomine.domain.image.UploadedFile;
@@ -42,8 +43,6 @@ import be.cytomine.domain.ontology.Ontology;
 import be.cytomine.repository.command.CommandRepository;
 import be.cytomine.repository.ontology.OntologyRepository;
 import be.cytomine.service.image.UploadedFileService;
-
-import org.springframework.context.annotation.Import;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -56,6 +55,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Import({MongoTestConfiguration.class, PostGisTestConfiguration.class})
 public class CommandControllerTests {
+
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     private BasicInstanceBuilder builder;
@@ -138,7 +140,7 @@ public class CommandControllerTests {
     @WithMockUser(username = "superadmin")
     public void undo_redo() throws Exception {
 
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         ontology.setName("undo_redo");
         restCommandControllerMockMvc.perform(
                 post("/api/ontology.json").contentType(MediaType.APPLICATION_JSON)
@@ -181,7 +183,7 @@ public class CommandControllerTests {
     @WithMockUser(username = "superadmin")
     public void undo_redo_with_command_id() throws Exception {
 
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         ontology.setName("undo_redo");
         restCommandControllerMockMvc.perform(
                 post("/api/ontology.json").contentType(MediaType.APPLICATION_JSON)

--- a/core/src/test/java/be/cytomine/controller/image/server/StorageResourceTests.java
+++ b/core/src/test/java/be/cytomine/controller/image/server/StorageResourceTests.java
@@ -12,13 +12,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import be.cytomine.BasicInstanceBuilder;
 import be.cytomine.CytomineCoreApplication;
-import be.cytomine.config.MongoTestConfiguration;
 import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
 import be.cytomine.domain.image.server.Storage;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -27,6 +30,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WithMockUser(username = "superadmin")
 @Import({MongoTestConfiguration.class, PostGisTestConfiguration.class})
 public class StorageResourceTests {
+
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     private BasicInstanceBuilder builder;
@@ -76,7 +82,8 @@ public class StorageResourceTests {
     @Test
     @Transactional
     public void add_valid_storage() throws Exception {
-        Storage storage = BasicInstanceBuilder.given_a_not_persisted_storage(builder.given_superadmin());
+        Storage storage =
+            basicInstanceBuilder.given_a_not_persisted_storage(builder.given_superadmin());
         restStorageControllerMockMvc.perform(post("/api/storage.json")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(storage.toJSON()))
@@ -94,7 +101,8 @@ public class StorageResourceTests {
     @Test
     @Transactional
     public void add_storage_refused_if_name_not_set() throws Exception {
-        Storage storage = BasicInstanceBuilder.given_a_not_persisted_storage(builder.given_superadmin());
+        Storage storage =
+            basicInstanceBuilder.given_a_not_persisted_storage(builder.given_superadmin());
         storage.setName(null);
         restStorageControllerMockMvc.perform(post("/api/storage.json")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/core/src/test/java/be/cytomine/controller/ontology/OntologyResourceTests.java
+++ b/core/src/test/java/be/cytomine/controller/ontology/OntologyResourceTests.java
@@ -16,14 +16,7 @@ package be.cytomine.controller.ontology;
 * limitations under the License.
 */
 
-import be.cytomine.BasicInstanceBuilder;
-import be.cytomine.CytomineCoreApplication;
-import be.cytomine.config.MongoTestConfiguration;
-import be.cytomine.common.PostGisTestConfiguration;
-import be.cytomine.domain.ontology.Ontology;
-import be.cytomine.domain.ontology.RelationTerm;
-import be.cytomine.domain.ontology.Term;
-import be.cytomine.domain.project.Project;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -34,10 +27,21 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.persistence.EntityManager;
+import be.cytomine.BasicInstanceBuilder;
+import be.cytomine.CytomineCoreApplication;
+import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
+import be.cytomine.domain.ontology.Ontology;
+import be.cytomine.domain.ontology.RelationTerm;
+import be.cytomine.domain.ontology.Term;
+import be.cytomine.domain.project.Project;
 
-import static org.hamcrest.Matchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -46,6 +50,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WithMockUser(username = "superadmin")
 @Import({MongoTestConfiguration.class, PostGisTestConfiguration.class})
 public class OntologyResourceTests {
+
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     private EntityManager em;
@@ -145,7 +152,7 @@ public class OntologyResourceTests {
     @Test
     @Transactional
     public void add_valid_ontology() throws Exception {
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         restOntologyControllerMockMvc.perform(post("/api/ontology.json")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(ontology.toJSON()))
@@ -164,7 +171,7 @@ public class OntologyResourceTests {
     @Test
     @Transactional
     public void add_ontology_refused_if_already_exists() throws Exception {
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         builder.persistAndReturn(ontology);
         restOntologyControllerMockMvc.perform(post("/api/ontology.json")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -176,7 +183,7 @@ public class OntologyResourceTests {
     @Test
     @Transactional
     public void add_ontology_refused_if_name_not_set() throws Exception {
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         ontology.setName(null);
         restOntologyControllerMockMvc.perform(post("/api/ontology.json")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/core/src/test/java/be/cytomine/controller/ontology/RelationTermResourceTests.java
+++ b/core/src/test/java/be/cytomine/controller/ontology/RelationTermResourceTests.java
@@ -16,12 +16,7 @@ package be.cytomine.controller.ontology;
 * limitations under the License.
 */
 
-import be.cytomine.BasicInstanceBuilder;
-import be.cytomine.CytomineCoreApplication;
-import be.cytomine.config.MongoTestConfiguration;
-import be.cytomine.common.PostGisTestConfiguration;
-import be.cytomine.domain.ontology.Ontology;
-import be.cytomine.domain.ontology.RelationTerm;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -32,10 +27,17 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.persistence.EntityManager;
+import be.cytomine.BasicInstanceBuilder;
+import be.cytomine.CytomineCoreApplication;
+import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
+import be.cytomine.domain.ontology.Ontology;
+import be.cytomine.domain.ontology.RelationTerm;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -44,6 +46,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WithMockUser(username = "superadmin")
 @Import({MongoTestConfiguration.class, PostGisTestConfiguration.class})
 public class RelationTermResourceTests {
+
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     private EntityManager em;
@@ -119,7 +124,9 @@ public class RelationTermResourceTests {
     @Transactional
     public void add_valid_relation() throws Exception {
         Ontology ontology = builder.given_an_ontology();
-        RelationTerm relationTerm = BasicInstanceBuilder.given_a_not_persisted_relation_term(builder.given_a_relation(), builder.given_a_term(ontology), builder.given_a_term(ontology));
+        RelationTerm relationTerm =
+            basicInstanceBuilder.given_a_not_persisted_relation_term(builder.given_a_relation(),
+                builder.given_a_term(ontology), builder.given_a_term(ontology));
         restRelationTermControllerMockMvc.perform(post("/api/relation/parent/term.json")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(relationTerm.toJSON()))

--- a/core/src/test/java/be/cytomine/controller/ontology/TermResourceTests.java
+++ b/core/src/test/java/be/cytomine/controller/ontology/TermResourceTests.java
@@ -16,13 +16,9 @@ package be.cytomine.controller.ontology;
 * limitations under the License.
 */
 
-import be.cytomine.BasicInstanceBuilder;
-import be.cytomine.CytomineCoreApplication;
-import be.cytomine.config.MongoTestConfiguration;
-import be.cytomine.common.PostGisTestConfiguration;
-import be.cytomine.domain.ontology.Term;
-import be.cytomine.domain.project.Project;
-import be.cytomine.utils.JsonObject;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -33,17 +29,20 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.persistence.EntityManager;
-
-import java.util.List;
+import be.cytomine.BasicInstanceBuilder;
+import be.cytomine.CytomineCoreApplication;
+import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
+import be.cytomine.domain.ontology.Term;
+import be.cytomine.domain.project.Project;
+import be.cytomine.utils.JsonObject;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -52,6 +51,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WithMockUser(username = "superadmin")
 @Import({MongoTestConfiguration.class, PostGisTestConfiguration.class})
 public class TermResourceTests {
+
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     private EntityManager em;
@@ -115,7 +117,7 @@ public class TermResourceTests {
     @Test
     @Transactional
     public void add_valid_term() throws Exception {
-        Term term = BasicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
+        Term term = basicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
         restTermControllerMockMvc.perform(post("/api/term.json")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(term.toJSON()))
@@ -135,8 +137,8 @@ public class TermResourceTests {
     @Test
     @Transactional
     public void add_valid_term_by_group() throws Exception {
-        Term term1 = BasicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
-        Term term2 = BasicInstanceBuilder.given_a_not_persisted_term(term1.getOntology());
+        Term term1 = basicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
+        Term term2 = basicInstanceBuilder.given_a_not_persisted_term(term1.getOntology());
         restTermControllerMockMvc.perform(post("/api/term.json")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(JsonObject.toJsonString(List.of(term1.toJsonObject(),term2.toJsonObject()))))
@@ -147,7 +149,7 @@ public class TermResourceTests {
     @Test
     @Transactional
     public void add_term_refused_if_already_exists() throws Exception {
-        Term term = BasicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
+        Term term = basicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
         builder.persistAndReturn(term);
         restTermControllerMockMvc.perform(post("/api/term.json")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -160,7 +162,7 @@ public class TermResourceTests {
     @Test
     @Transactional
     public void add_term_refused_if_ontology_not_set() throws Exception {
-        Term term = BasicInstanceBuilder.given_a_not_persisted_term(null);
+        Term term = basicInstanceBuilder.given_a_not_persisted_term(null);
         restTermControllerMockMvc.perform(post("/api/term.json")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(term.toJSON()))
@@ -172,7 +174,7 @@ public class TermResourceTests {
     @Test
     @Transactional
     public void add_term_refused_if_name_not_set() throws Exception {
-        Term term = BasicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
+        Term term = basicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
         term.setName(null);
         restTermControllerMockMvc.perform(post("/api/term.json")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/core/src/test/java/be/cytomine/controller/project/ProjectResourceTests.java
+++ b/core/src/test/java/be/cytomine/controller/project/ProjectResourceTests.java
@@ -20,11 +20,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import be.cytomine.config.MongoTestConfiguration;
-import be.cytomine.common.PostGisTestConfiguration;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-
 import jakarta.persistence.EntityManager;
 import org.apache.commons.lang3.time.DateUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -37,11 +34,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import be.cytomine.BasicInstanceBuilder;
 import be.cytomine.CytomineCoreApplication;
+import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
 import be.cytomine.domain.meta.TagDomainAssociation;
 import be.cytomine.domain.ontology.AnnotationTerm;
 import be.cytomine.domain.ontology.Ontology;
@@ -59,9 +59,6 @@ import be.cytomine.service.PermissionService;
 import be.cytomine.service.ontology.UserAnnotationService;
 import be.cytomine.service.social.ProjectConnectionService;
 
-import org.springframework.security.test.context.support.WithMockUser;
-
-
 import static be.cytomine.service.middleware.ImageServerService.IMS_API_BASE_PATH;
 import static be.cytomine.service.search.RetrievalService.CBIR_API_BASE_PATH;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -70,10 +67,17 @@ import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.springframework.security.acls.domain.BasePermission.ADMINISTRATION;
 import static org.springframework.security.acls.domain.BasePermission.READ;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -82,6 +86,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WithMockUser(username = "superadmin")
 @Import({MongoTestConfiguration.class, PostGisTestConfiguration.class})
 public class ProjectResourceTests {
+
+    @Autowired
+    private BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     private EntityManager em;
@@ -521,7 +528,7 @@ public class ProjectResourceTests {
     @Test
     @Transactional
     public void add_valid_project() throws Exception {
-        Project project = BasicInstanceBuilder.given_a_not_persisted_project();
+        Project project = basicInstanceBuilder.given_a_not_persisted_project();
         project.setOntology(builder.given_an_ontology());
         project.setName("add_valid_project");
 
@@ -549,7 +556,7 @@ public class ProjectResourceTests {
     @Test
     @Transactional
     public void add_valid_project_without_ontology() throws Exception {
-        Project project = BasicInstanceBuilder.given_a_not_persisted_project();
+        Project project = basicInstanceBuilder.given_a_not_persisted_project();
         project.setOntology(null);
 
         /* Test project creation */
@@ -575,7 +582,7 @@ public class ProjectResourceTests {
         User user = builder.given_a_user();
         User admin = builder.given_a_user();
 
-        Project project = BasicInstanceBuilder.given_a_not_persisted_project();
+        Project project = basicInstanceBuilder.given_a_not_persisted_project();
         project.setOntology(builder.given_an_ontology());
         project.setName("add_valid_project_with_users_admins");
         restProjectControllerMockMvc.perform(post("/api/project.json")

--- a/core/src/test/java/be/cytomine/domain/CytomineDomainTests.java
+++ b/core/src/test/java/be/cytomine/domain/CytomineDomainTests.java
@@ -16,12 +16,11 @@ package be.cytomine.domain;
 * limitations under the License.
 */
 
-import be.cytomine.BasicInstanceBuilder;
-import be.cytomine.CytomineCoreApplication;
-import be.cytomine.config.CustomIdentifierGenerator;
-import be.cytomine.config.MongoTestConfiguration;
-import be.cytomine.common.PostGisTestConfiguration;
-import be.cytomine.domain.ontology.Ontology;
+import java.util.Date;
+import java.util.UUID;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -29,11 +28,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
-
-import java.util.Date;
-import java.util.UUID;
+import be.cytomine.BasicInstanceBuilder;
+import be.cytomine.CytomineCoreApplication;
+import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.CustomIdentifierGenerator;
+import be.cytomine.config.MongoTestConfiguration;
+import be.cytomine.domain.ontology.Ontology;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -45,6 +45,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class CytomineDomainTests {
 
     @Autowired
+    BasicInstanceBuilder basicInstanceBuilder;
+
+    @Autowired
     BasicInstanceBuilder builder;
 
     @Autowired
@@ -52,7 +55,7 @@ public class CytomineDomainTests {
 
     @Test
     void assign_id_automatically() {
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         assertThat(ontology.getId()).isNull();
         ontology = builder.persistAndReturn(ontology);
         assertThat(ontology.getId()).isPositive();
@@ -61,7 +64,7 @@ public class CytomineDomainTests {
     @Test
     void assign_created_date() {
         Date beforeCreate = new Date();
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         assertThat(ontology.getCreated()).isNull();
         ontology = builder.persistAndReturn(ontology);
         Date afterCreate = new Date();
@@ -71,7 +74,7 @@ public class CytomineDomainTests {
     @Test
     void assign_updated_date() {
         Date beforeCreate = new Date();
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         assertThat(ontology.getUpdated()).isNull();
         ontology = builder.persistAndReturn(ontology);
         Date afterCreate = new Date();
@@ -88,7 +91,7 @@ public class CytomineDomainTests {
     @Test
     void preserve_preassigned_id() {
         Long preassignedId = 999999999L;
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         ontology.setId(preassignedId);
         assertThat(ontology.getId()).isEqualTo(preassignedId);
         ontology = builder.persistAndReturn(ontology);

--- a/core/src/test/java/be/cytomine/service/ontology/OntologyServiceTests.java
+++ b/core/src/test/java/be/cytomine/service/ontology/OntologyServiceTests.java
@@ -19,8 +19,6 @@ package be.cytomine.service.ontology;
 import java.util.List;
 import java.util.UUID;
 
-import be.cytomine.config.MongoTestConfiguration;
-import be.cytomine.common.PostGisTestConfiguration;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import jakarta.transaction.Transactional;
@@ -36,6 +34,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import be.cytomine.BasicInstanceBuilder;
 import be.cytomine.CytomineCoreApplication;
+import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
 import be.cytomine.domain.ontology.Ontology;
 import be.cytomine.domain.ontology.RelationTerm;
 import be.cytomine.domain.ontology.Term;
@@ -74,6 +74,9 @@ public class OntologyServiceTests {
 
     @Autowired
     OntologyRepository ontologyRepository;
+
+    @Autowired
+    BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     BasicInstanceBuilder builder;
@@ -160,7 +163,7 @@ public class OntologyServiceTests {
 
     @Test
     void add_valid_ontology_with_success() {
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
 
         CommandResponse commandResponse = ontologyService.add(ontology.toJsonObject());
 
@@ -173,7 +176,7 @@ public class OntologyServiceTests {
 
     @Test
     void add_ontology_with_null_name_fail() {
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         ontology.setName("");
         Assertions.assertThrows(WrongArgumentException.class, () -> {
             ontologyService.add(ontology.toJsonObject());
@@ -183,7 +186,7 @@ public class OntologyServiceTests {
 
     @Test
     void undo_redo_ontology_creation_with_success() {
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         CommandResponse commandResponse = ontologyService.add(ontology.toJsonObject());
         assertThat(ontologyService.find(commandResponse.getObject().getId())).isPresent();
         System.out.println(
@@ -201,7 +204,7 @@ public class OntologyServiceTests {
 
     @Test
     void redo_ontology_creation_fail_if_ontology_already_exist() {
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         CommandResponse commandResponse = ontologyService.add(ontology.toJsonObject());
         assertThat(ontologyService.find(commandResponse.getObject().getId())).isPresent();
         System.out.println(
@@ -211,7 +214,7 @@ public class OntologyServiceTests {
 
         assertThat(ontologyService.find(commandResponse.getObject().getId())).isEmpty();
 
-        Ontology ontologyWithSameName = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontologyWithSameName = basicInstanceBuilder.given_a_not_persisted_ontology();
         ontologyWithSameName.setName(ontology.getName());
         builder.persistAndReturn(ontologyWithSameName);
 
@@ -376,7 +379,7 @@ public class OntologyServiceTests {
     void determine_rights_for_users_keep_rights_for_ontology_creator() {
 
         // create ontology for user
-        Ontology ontology = BasicInstanceBuilder.given_a_not_persisted_ontology();
+        Ontology ontology = basicInstanceBuilder.given_a_not_persisted_ontology();
         CommandResponse commandResponse = ontologyService.add(ontology.toJsonObject());
         ontology = (Ontology) commandResponse.getObject();
 
@@ -385,7 +388,7 @@ public class OntologyServiceTests {
         assertThat(permissionService.hasACLPermission(ontology, "user", READ)).isTrue();
 
         // create project with ontology
-        Project project = BasicInstanceBuilder.given_a_not_persisted_project();
+        Project project = basicInstanceBuilder.given_a_not_persisted_project();
         project.setOntology(ontology);
         commandResponse = projectService.add(project.toJsonObject());
         project = (Project) commandResponse.getObject();

--- a/core/src/test/java/be/cytomine/service/ontology/RelationTermServiceTests.java
+++ b/core/src/test/java/be/cytomine/service/ontology/RelationTermServiceTests.java
@@ -16,16 +16,9 @@ package be.cytomine.service.ontology;
 * limitations under the License.
 */
 
-import be.cytomine.BasicInstanceBuilder;
-import be.cytomine.CytomineCoreApplication;
-import be.cytomine.config.MongoTestConfiguration;
-import be.cytomine.common.PostGisTestConfiguration;
-import be.cytomine.domain.ontology.RelationTerm;
-import be.cytomine.domain.ontology.Term;
-import be.cytomine.exceptions.ObjectNotFoundException;
-import be.cytomine.repository.ontology.RelationTermRepository;
-import be.cytomine.service.CommandService;
-import be.cytomine.utils.CommandResponse;
+import java.util.Optional;
+
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,9 +27,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import jakarta.transaction.Transactional;
-
-import java.util.Optional;
+import be.cytomine.BasicInstanceBuilder;
+import be.cytomine.CytomineCoreApplication;
+import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
+import be.cytomine.domain.ontology.RelationTerm;
+import be.cytomine.domain.ontology.Term;
+import be.cytomine.exceptions.ObjectNotFoundException;
+import be.cytomine.repository.ontology.RelationTermRepository;
+import be.cytomine.service.CommandService;
+import be.cytomine.utils.CommandResponse;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -52,6 +52,9 @@ public class RelationTermServiceTests {
 
     @Autowired
     RelationTermRepository relationTermRepository;
+
+    @Autowired
+    BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     BasicInstanceBuilder builder;
@@ -104,7 +107,9 @@ public class RelationTermServiceTests {
     void add_valid_relation_term_with_success() {
         Term parent = builder.given_a_term();
         Term child1 = builder.given_a_term(parent.getOntology());
-        RelationTerm parentRelationTerm = BasicInstanceBuilder.given_a_not_persisted_relation_term(builder.given_a_relation(), parent, child1);
+        RelationTerm parentRelationTerm =
+            basicInstanceBuilder.given_a_not_persisted_relation_term(builder.given_a_relation(),
+                parent, child1);
 
         CommandResponse commandResponse = relationTermService.add(parentRelationTerm.toJsonObject());
 
@@ -116,7 +121,9 @@ public class RelationTermServiceTests {
     @Test
     void add_relation_term_with_null_term_fail() {
         Term parent = builder.given_a_term();
-        RelationTerm parentRelationTerm = BasicInstanceBuilder.given_a_not_persisted_relation_term(builder.given_a_relation(), parent, null);
+        RelationTerm parentRelationTerm =
+            basicInstanceBuilder.given_a_not_persisted_relation_term(builder.given_a_relation(),
+                parent, null);
         Assertions.assertThrows(ObjectNotFoundException.class, () -> {
             relationTermService.add(parentRelationTerm.toJsonObject());
         });

--- a/core/src/test/java/be/cytomine/service/ontology/TermServiceTests.java
+++ b/core/src/test/java/be/cytomine/service/ontology/TermServiceTests.java
@@ -16,11 +16,25 @@ package be.cytomine.service.ontology;
 * limitations under the License.
 */
 
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+
 import be.cytomine.BasicInstanceBuilder;
 import be.cytomine.CytomineCoreApplication;
-import be.cytomine.config.MongoTestConfiguration;
 import be.cytomine.common.PostGisTestConfiguration;
-import be.cytomine.domain.ontology.*;
+import be.cytomine.config.MongoTestConfiguration;
+import be.cytomine.domain.ontology.AnnotationTerm;
+import be.cytomine.domain.ontology.Ontology;
+import be.cytomine.domain.ontology.RelationTerm;
+import be.cytomine.domain.ontology.ReviewedAnnotation;
+import be.cytomine.domain.ontology.Term;
 import be.cytomine.domain.project.Project;
 import be.cytomine.exceptions.AlreadyExistException;
 import be.cytomine.exceptions.ConstraintException;
@@ -30,16 +44,6 @@ import be.cytomine.repository.ontology.TermRepository;
 import be.cytomine.service.CommandService;
 import be.cytomine.service.command.TransactionService;
 import be.cytomine.utils.CommandResponse;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.security.test.context.support.WithMockUser;
-
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -55,6 +59,9 @@ public class TermServiceTests {
 
     @Autowired
     TermRepository termRepository;
+
+    @Autowired
+    BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     BasicInstanceBuilder builder;
@@ -157,7 +164,7 @@ public class TermServiceTests {
     @Test
     void add_valid_term_with_success() {
         Ontology ontology = builder.given_an_ontology();
-        Term term = BasicInstanceBuilder.given_a_not_persisted_term(ontology);
+        Term term = basicInstanceBuilder.given_a_not_persisted_term(ontology);
 
         CommandResponse commandResponse = termService.add(term.toJsonObject());
 
@@ -171,7 +178,7 @@ public class TermServiceTests {
 
     @Test
     void add_term_with_null_ontology_fail() {
-        Term term = BasicInstanceBuilder.given_a_not_persisted_term(null);
+        Term term = basicInstanceBuilder.given_a_not_persisted_term(null);
         Assertions.assertThrows(WrongArgumentException.class, () -> {
             termService.add(term.toJsonObject());
         });
@@ -179,7 +186,7 @@ public class TermServiceTests {
 
     @Test
     void add_term_with_null_color_fail() {
-        Term term = BasicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
+        Term term = basicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
         term.setColor(null);
         Assertions.assertThrows(WrongArgumentException.class, () -> {
             termService.add(term.toJsonObject());
@@ -188,7 +195,7 @@ public class TermServiceTests {
 
     @Test
     void undo_redo_term_creation_with_success() {
-        Term term = BasicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
+        Term term = basicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
         CommandResponse commandResponse = termService.add(term.toJsonObject());
         assertThat(termService.find(commandResponse.getObject().getId())).isPresent();
         System.out.println("id = " + commandResponse.getObject().getId() + " name = " + term.getName());
@@ -205,7 +212,7 @@ public class TermServiceTests {
 
     @Test
     void redo_term_creation_fail_if_term_already_exist() {
-        Term term = BasicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
+        Term term = basicInstanceBuilder.given_a_not_persisted_term(builder.given_an_ontology());
         CommandResponse commandResponse = termService.add(term.toJsonObject());
         assertThat(termService.find(commandResponse.getObject().getId())).isPresent();
         System.out.println("id = " + commandResponse.getObject().getId() + " name = " + term.getName());
@@ -214,7 +221,7 @@ public class TermServiceTests {
 
         assertThat(termService.find(commandResponse.getObject().getId())).isEmpty();
 
-        Term termWithSameName = BasicInstanceBuilder.given_a_not_persisted_term(term.getOntology());
+        Term termWithSameName = basicInstanceBuilder.given_a_not_persisted_term(term.getOntology());
         termWithSameName.setName(term.getName());
         builder.persistAndReturn(termWithSameName);
 

--- a/core/src/test/java/be/cytomine/service/processing/ImageFilterProjectServiceTests.java
+++ b/core/src/test/java/be/cytomine/service/processing/ImageFilterProjectServiceTests.java
@@ -1,13 +1,6 @@
 package be.cytomine.service.processing;
 
-import be.cytomine.BasicInstanceBuilder;
-import be.cytomine.CytomineCoreApplication;
-import be.cytomine.config.MongoTestConfiguration;
-import be.cytomine.common.PostGisTestConfiguration;
-import be.cytomine.domain.processing.ImageFilterProject;
-import be.cytomine.exceptions.AlreadyExistException;
-import be.cytomine.exceptions.ObjectNotFoundException;
-import be.cytomine.utils.CommandResponse;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +9,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import jakarta.transaction.Transactional;
+import be.cytomine.BasicInstanceBuilder;
+import be.cytomine.CytomineCoreApplication;
+import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
+import be.cytomine.domain.processing.ImageFilterProject;
+import be.cytomine.exceptions.AlreadyExistException;
+import be.cytomine.exceptions.ObjectNotFoundException;
+import be.cytomine.utils.CommandResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,6 +29,9 @@ public class ImageFilterProjectServiceTests {
 
     @Autowired
     ImageFilterProjectService imageFilterProjectService;
+
+    @Autowired
+    BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     BasicInstanceBuilder builder;
@@ -85,7 +88,8 @@ public class ImageFilterProjectServiceTests {
     @Test
     public void add_image_filter_with_unexisting_project_return_error() {
         ImageFilterProject imageFilterProject =
-                builder.given_a_not_persisted_image_filter_project(builder.given_a_image_filter(), BasicInstanceBuilder.given_a_not_persisted_project());
+            builder.given_a_not_persisted_image_filter_project(builder.given_a_image_filter(),
+                basicInstanceBuilder.given_a_not_persisted_project());
         Assertions.assertThrows(ObjectNotFoundException.class, () -> {
             imageFilterProjectService.add(imageFilterProject.toJsonObject().withChange("project", 0L));
         });

--- a/core/src/test/java/be/cytomine/service/project/ProjectServiceTests.java
+++ b/core/src/test/java/be/cytomine/service/project/ProjectServiceTests.java
@@ -16,16 +16,27 @@ package be.cytomine.service.project;
 * limitations under the License.
 */
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
-import be.cytomine.config.MongoTestConfiguration;
-import be.cytomine.common.PostGisTestConfiguration;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.time.DateUtils;
 import org.assertj.core.api.AssertionsForClassTypes;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,11 +45,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-
 import be.cytomine.BasicInstanceBuilder;
 import be.cytomine.CytomineCoreApplication;
+import be.cytomine.common.PostGisTestConfiguration;
+import be.cytomine.config.MongoTestConfiguration;
 import be.cytomine.domain.meta.AttachedFile;
 import be.cytomine.domain.meta.Description;
 import be.cytomine.domain.meta.Property;
@@ -86,6 +96,9 @@ public class ProjectServiceTests {
 
     @Autowired
     ProjectService projectService;
+
+    @Autowired
+    BasicInstanceBuilder basicInstanceBuilder;
 
     @Autowired
     BasicInstanceBuilder builder;
@@ -704,7 +717,7 @@ public class ProjectServiceTests {
 
     @Test
     void add_project() {
-        Project project = BasicInstanceBuilder.given_a_not_persisted_project();
+        Project project = basicInstanceBuilder.given_a_not_persisted_project();
 
         CommandResponse commandResponse = projectService.add(project.toJsonObject());
 
@@ -723,7 +736,7 @@ public class ProjectServiceTests {
 
     @Test
     void add_project_with_users_and_admins() {
-        Project project = BasicInstanceBuilder.given_a_not_persisted_project();
+        Project project = basicInstanceBuilder.given_a_not_persisted_project();
         project.setOntology(builder.given_an_ontology());
         User user = builder.given_a_user();
         User admin = builder.given_a_user();
@@ -934,7 +947,7 @@ public class ProjectServiceTests {
 
     @Test
     void delete_project_just_beeing_created() {
-        Project project = BasicInstanceBuilder.given_a_not_persisted_project();
+        Project project = basicInstanceBuilder.given_a_not_persisted_project();
 
         CommandResponse commandResponse = projectService.add(project.toJsonObject());
 


### PR DESCRIPTION
the only real change here is:
```diff
-    private static User aUser;
-    private static User anAdmin;
-    private static User aGuest;
+    private User aUser;
+    private User anAdmin;
+    private User aGuest;
```

the rest is optimize imports + autowire `BasicBuilderInstance` and access it non-statically