### PR TITLE
fix: only get the version of helm

### DIFF
--- a/.github/workflows/helm-main.yaml
+++ b/.github/workflows/helm-main.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get version
         run: |
-          echo "CHART_VERSION=$(cat ./charts/cytomine/Chart.yaml | grep "version:" | sed -E 's/^version: (.*)$/\1/g')" >> $GITHUB_ENV
+          echo "CHART_VERSION=$(cat ./charts/cytomine/Chart.yaml | grep "^version:" | sed -E 's/^version: (.*)$/\1/g')" >> $GITHUB_ENV
 
       - name: Install Helm
         uses: azure/setup-helm@v5


### PR DESCRIPTION
fix https://github.com/cytomine/cytomine/actions/runs/24893430780/job/72894228395, where the grep matches all version instead of the first one, by adding `^` to `version`, we ensure that we only match where `version:` appears at the very beginning of the line