### PR TITLE
chore: bump node from 20.19.4 to 22.22.3

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -1,6 +1,6 @@
 java-version: "21"
 java-distribution: "temurin"
 gradle-version: "8.14"
-node-version: "20.19.4"
+node-version: "22.22.3"
 python-version: "3.10"
 uv-version: "0.9.30"

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ The documentation site is built using VuePress v1.
 
 ## Requirements
 
-- [Node](https://nodejs.org/) (v20.19.4+ recommended)
+- [Node](https://nodejs.org/) (v22.22.3+ recommended)
 
 ## Usage
 

--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -1,7 +1,7 @@
 ARG PROXY_CACHE=registry.cytomine.org/docker
 ARG WEB_UI_VERSION
 ARG WEB_UI_REVISION
-ARG NODE_VERSION=20.19.4
+ARG NODE_VERSION=22.22.3
 ARG NGINX_VERSION=1.22.1
 
 #######################################################################################


### PR DESCRIPTION
Node 20 has reached EOL since 30 April 2026.
Move to the next LTS Node 22