### PR TITLE
fix(helm): use ping probe for liveness and startup

### DIFF
--- a/helm/charts/cytomine/templates/pims/pims-service.yaml
+++ b/helm/charts/cytomine/templates/pims/pims-service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: pims
 spec:
-  clusterIP: None
   selector:
     app: pims
   ports:

--- a/helm/charts/cytomine/templates/pims/pims.yaml
+++ b/helm/charts/cytomine/templates/pims/pims.yaml
@@ -118,7 +118,7 @@ spec:
               containerPort: {{ .Values.pims.port }}
           startupProbe:
             httpGet:
-              path: /ims/disk-usage
+              path: /ims/ping
               port: {{ .Values.pims.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -133,7 +133,7 @@ spec:
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /ims/disk-usage
+              path: /ims/ping
               port: {{ .Values.pims.port }}
             periodSeconds: 10
             failureThreshold: 3

--- a/pims/pims/api/server.py
+++ b/pims/pims/api/server.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 from pims import __version__
 from pims.config import ReadableSettings, get_settings
 
-router = APIRouter(prefix=get_settings().api_base_path)
+router = APIRouter(prefix=get_settings().api_base_path, tags=["Server"])
 
 
 class ServerInfo(BaseModel):
@@ -12,7 +12,12 @@ class ServerInfo(BaseModel):
     settings: ReadableSettings
 
 
-@router.get("/info", tags=["Server"])
+@router.get("/ping")
+def ping() -> dict:
+    return {"ping": "pong"}
+
+
+@router.get("/info")
 async def show_status() -> ServerInfo:
     """
     PIMS Server status.

--- a/pims/tests/test_api_server.py
+++ b/pims/tests/test_api_server.py
@@ -1,6 +1,12 @@
 from pims import __version__
 
 
+def test_ping(app, client):
+    response = client.get("/ping")
+    assert response.status_code == 200
+    assert response.json() == {"ping": "pong"}
+
+
 def test_status(app, client):
     response = client.get("/info")
     assert response.status_code == 200


### PR DESCRIPTION
part of #915 

- Create an endpoint `/ping` to avoid using `/disk-usage` when pims import is triggered since it is under heavy IO load.