### PR TITLE
chore(k3s): bump k3s to rancher/k3s:v1.30.14-rc3-k3s3

### DIFF
--- a/app-engine/src/test/java/be/cytomine/appengine/config/K3sConfiguration.java
+++ b/app-engine/src/test/java/be/cytomine/appengine/config/K3sConfiguration.java
@@ -10,30 +10,25 @@ import org.testcontainers.utility.DockerImageName;
 public class K3sConfiguration {
     @Bean
     K3sContainer k3s() {
-        K3sContainer k3sContainer =
-            new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"))
-                .withCommand("server", "--disable", "metrics-server");
+        K3sContainer k3sContainer = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.30.14-rc3-k3s3"))
+            .withCommand("server", "--disable", "metrics-server");
 
         // don't normally need to start the container in these @Bean methods but can't get the
         // config unless its started
         k3sContainer.start();
 
         String kubeConfigYaml = k3sContainer.getKubeConfigYaml();
-        Config config = Config.fromKubeconfig(
-            kubeConfigYaml);  // requires io.fabric8:kubernetes-client:5.11.0 or higher
+        // requires io.fabric8:kubernetes-client:5.11.0 or higher
+        Config config = Config.fromKubeconfig(kubeConfigYaml);
 
         // in the absence of @ServiceConnection integration for this testcontainer, Jack the test
         // container URL into properties so it's picked up when I create a client in main app
         System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, config.getMasterUrl());
-        System.setProperty(Config.KUBERNETES_CA_CERTIFICATE_DATA_SYSTEM_PROPERTY,
-            config.getCaCertData());
-        System.setProperty(Config.KUBERNETES_CLIENT_CERTIFICATE_DATA_SYSTEM_PROPERTY,
-            config.getClientCertData());
-        System.setProperty(Config.KUBERNETES_CLIENT_KEY_DATA_SYSTEM_PROPERTY,
-            config.getClientKeyData());
+        System.setProperty(Config.KUBERNETES_CA_CERTIFICATE_DATA_SYSTEM_PROPERTY, config.getCaCertData());
+        System.setProperty(Config.KUBERNETES_CLIENT_CERTIFICATE_DATA_SYSTEM_PROPERTY, config.getClientCertData());
+        System.setProperty(Config.KUBERNETES_CLIENT_KEY_DATA_SYSTEM_PROPERTY, config.getClientKeyData());
         System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
 
         return k3sContainer;
     }
-
 }

--- a/app-engine/src/test/java/be/cytomine/appengine/integration/cucumber/RunCucumberIntegrationTests.java
+++ b/app-engine/src/test/java/be/cytomine/appengine/integration/cucumber/RunCucumberIntegrationTests.java
@@ -42,12 +42,12 @@ public class RunCucumberIntegrationTests {
 
     @Container
     static GenericContainer<?> registryContainer = new GenericContainer<>("registry:2.8.3")
-            .withExposedPorts(REGISTRY_INTERNAL_PORT);
+        .withExposedPorts(REGISTRY_INTERNAL_PORT);
 
     @Container
-    static K3sContainer k3sContainer = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"))
-            .withCommand("server", "--disable", "metrics-server")
-            .withStartupTimeout(Duration.ofMinutes(5));
+    static K3sContainer k3sContainer = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.30.14-rc3-k3s3"))
+        .withCommand("server", "--disable", "metrics-server")
+        .withStartupTimeout(Duration.ofMinutes(5));
 
     @BeforeClass
     public static void startContainers() throws IOException {
@@ -55,9 +55,9 @@ public class RunCucumberIntegrationTests {
         k3sContainer.start();
 
         String registryUrl = String.format(
-                "http://%s:%d",
-                registryContainer.getHost(),
-                registryContainer.getMappedPort(REGISTRY_INTERNAL_PORT)
+            "http://%s:%d",
+            registryContainer.getHost(),
+            registryContainer.getMappedPort(REGISTRY_INTERNAL_PORT)
         );
 
         System.setProperty("registry.url", registryUrl);
@@ -71,22 +71,22 @@ public class RunCucumberIntegrationTests {
 
         try (KubernetesClient client = new KubernetesClientBuilder().withConfig(config).build()) {
             client.namespaces()
-                    .resource(new NamespaceBuilder()
-                            .withNewMetadata()
-                            .withName("tasks")
-                            .endMetadata()
-                            .build())
-                    .create();
+                .resource(new NamespaceBuilder()
+                    .withNewMetadata()
+                    .withName("tasks")
+                    .endMetadata()
+                    .build())
+                .create();
 
             client.serviceAccounts()
-                    .inNamespace("tasks")
-                    .resource(new ServiceAccountBuilder()
-                            .withNewMetadata()
-                            .withName("app-engine")
-                            .withNamespace("tasks")
-                            .endMetadata()
-                            .build())
-                    .create();
+                .inNamespace("tasks")
+                .resource(new ServiceAccountBuilder()
+                    .withNewMetadata()
+                    .withName("app-engine")
+                    .withNamespace("tasks")
+                    .endMetadata()
+                    .build())
+                .create();
         }
     }
 }


### PR DESCRIPTION
Our tests are running on k3s `rancher/k3s:v1.21.3-k3s1` whereas our local deployement uses `rancher/k3s:v1.30.14-rc3-k3s3`
- https://github.com/cytomine/cytomine/blob/main/compose.yaml#L312
- https://github.com/cytomine/cytomine/blob/main/helm/compose.yaml#L5