### PR TITLE
fix(web-ui): fetch annotation layer for review

### DIFF
--- a/web-ui/src/components/viewer/AnnotationLayer.vue
+++ b/web-ui/src/components/viewer/AnnotationLayer.vue
@@ -256,7 +256,6 @@ export default {
       let isFeatureSelected = indexSelectedFeature !== -1;
 
       if (!annot) {
-        console.log(`Removing annot ${feature.getId()} in layer ${this.layer.id} (external action)`);
         this.$refs.olSource.removeFeature(feature);
         if (isFeatureSelected) {
           this.$store.commit(this.imageModule + 'clearSelectedFeatures');
@@ -273,17 +272,14 @@ export default {
       if (isFeatureSelected) {
         if (this.ongoingEdit) {
           // if feature is selected and under modification, updating it may lead to conflict
-          console.log(`Skipping update of selected annot ${annot.id} in layer ${this.layer.id} (ongoing edit)`);
           return;
         }
-        console.log(`Updating selected annot ${annot.id} in layer ${this.layer.id} (external action)`);
         this.$store.commit(this.imageModule + 'changeAnnotSelectedFeature', {
           indexFeature: indexSelectedFeature,
           annot
         });
       }
 
-      console.log(`Updating annot ${annot.id} in layer ${this.layer.id} (external action)`);
       feature.set('annot', annot);
       feature.setGeometry(this.format.readGeometry(annot.location));
     },

--- a/web-ui/src/components/viewer/AnnotationLayer.vue
+++ b/web-ui/src/components/viewer/AnnotationLayer.vue
@@ -1,34 +1,12 @@
-<!-- Copyright (c) 2009-2022. Authors: see NOTICE file.
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.-->
-
 <template>
-<vl-layer-vector
-  :visible="layer.visible"
-  :extent="imageExtent"
-  :update-while-interacting="false"
->
+  <vl-layer-vector :visible="layer.visible" :extent="imageExtent" :update-while-interacting="false">
 
-  <vl-source-vector
-    ref="olSource"
-    :loader-factory="loaderFactory"
-    :strategy-factory="strategyFactory"
-    url="-"
-  > <!-- HACK because loader factory not used if URL not specified -->
-    <vl-style-func :factory="styleFunctionFactory" />
-  </vl-source-vector>
+    <vl-source-vector ref="olSource" :loader-factory="loaderFactory" :strategy-factory="strategyFactory" url="-">
+      <!-- HACK because loader factory not used if URL not specified -->
+      <vl-style-func :factory="styleFunctionFactory" />
+    </vl-source-vector>
 
-</vl-layer-vector>
+  </vl-layer-vector>
 </template>
 
 <script>
@@ -199,7 +177,7 @@ export default {
 
         if (this.$refs.olSource && this.resolution && this.clustered !== null && ( // some features have already been loaded
           !this.clustered && resolution > this.maxResolutionNoClusters // recluster
-                    || resolution !== this.resolution && this.clustered)) { // change of resolution while clustering
+          || resolution !== this.resolution && this.clustered)) { // change of resolution while clustering
 
           // clear loaded extents to force reloading features
           this.$refs.olSource.$source.loadedExtentsRtree_.clear();

--- a/web-ui/src/components/viewer/AnnotationLayer.vue
+++ b/web-ui/src/components/viewer/AnnotationLayer.vue
@@ -293,7 +293,9 @@ export default {
 
       let arrayAnnots;
       try {
-        if (Object.prototype.hasOwnProperty.call(this.layer, 'username')) {
+        const isUserAnnotation = Object.prototype.hasOwnProperty.call(this.layer, 'username');
+        const isReviewedAnnotation = Object.prototype.hasOwnProperty.call(this.layer, 'isReview');
+        if (isUserAnnotation || isReviewedAnnotation) {
           arrayAnnots = await this.fetchAnnots(extent);
           // Order by size, so bigger ones are always sent to back
           arrayAnnots.sort(

--- a/web-ui/tests/unit/components/viewer/AnnotationLayer.test.js
+++ b/web-ui/tests/unit/components/viewer/AnnotationLayer.test.js
@@ -1,0 +1,90 @@
+import {shallowMount} from '@vue/test-utils';
+
+import AnnotationLayer from '@/components/viewer/AnnotationLayer.vue';
+
+jest.mock('ol/format/WKT', () => {
+  const WKT = jest.fn().mockImplementation(() => ({
+    readFeature: jest.fn(),
+    readGeometry: jest.fn(),
+  }));
+  return {__esModule: true, default: WKT};
+});
+
+describe('AnnotationLayer.vue', () => {
+  const createWrapper = () => shallowMount(
+    AnnotationLayer,
+    {
+      propsData: {
+        index: '0',
+        layer: {id: 1, visible: true},
+      },
+      mocks: {
+        $eventBus: {
+          $on: jest.fn(),
+          $off: jest.fn(),
+        },
+        $store: {
+          getters: {
+            'currentProject/currentViewer': {
+              images: {
+                0: {
+                  imageInstance: {id: 10, width: 1000, height: 1000},
+                  activeSlices: [],
+                  selectedFeatures: {
+                    annotsToSelect: [],
+                    selectedFeatures: [],
+                  },
+                  draw: {
+                    ongoingEdit: false,
+                  },
+                  style: {
+                    terms: [],
+                    wrappedTracks: [],
+                  },
+                  properties: {
+                    selectedPropertyKey: null,
+                    selectedPropertyColor: null,
+                  },
+                  review: {},
+                }
+              },
+            },
+            'currentProject/imageModule': jest.fn(() => 'mock-module/'),
+          },
+        },
+      },
+      stubs: {
+        'vl-layer-vector': true,
+        'vl-source-vector': true,
+        'vl-style-func': true,
+      },
+    },
+  );
+
+  describe('addAnnotationHandler', () => {
+    it('should add feature when annotation belongs to layer', () => {
+      const wrapper = createWrapper();
+      const feature = {id: 1};
+      wrapper.vm.$refs.olSource = {addFeature: jest.fn()};
+      wrapper.vm.annotBelongsToLayer = jest.fn().mockReturnValue(true);
+      wrapper.vm.createFeature = jest.fn().mockReturnValue(feature);
+
+      wrapper.vm.addAnnotationHandler({id: 1});
+
+      expect(wrapper.vm.createFeature).toHaveBeenCalled();
+      expect(
+        wrapper.vm.$refs.olSource.addFeature
+      ).toHaveBeenCalledWith(feature);
+    });
+
+    it('should not add feature when annotation does not belong to layer', () => {
+      const wrapper = createWrapper();
+      wrapper.vm.$refs.olSource = {addFeature: jest.fn()};
+
+      wrapper.vm.annotBelongsToLayer = jest.fn().mockReturnValue(false);
+      wrapper.vm.addAnnotationHandler({id: 1});
+
+      expect(wrapper.vm.$refs.olSource.addFeature).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
before #962 

When the user clicks on review, the fetch for annotation layers failed since it tries to fetch for id -1.