### PR TITLE
fix(docker): weight path for sam

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -287,11 +287,9 @@ services:
     restart: unless-stopped
     ports:
       - 8000:8000
-    volumes:
-      - ${DATA_PATH:-./data}/weights:/weights
     environment:
-      API_BASE_PATH: ${SAM_API_BASE_PATH:-/sam}
-      WEIGHTS_PATH: /weights
+      API_BASE_PATH: /sam
+      WEIGHTS_PATH: /app/weights
     networks:
       host_network:
         ipv4_address: 172.16.238.13


### PR DESCRIPTION
Since #898, the weight path of sam service is now at `/app/weights`