### PR TITLE
refactor: http exchange root path

### DIFF
--- a/common/src/main/java/be/cytomine/common/repository/http/OntologyHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/OntologyHttpContract.java
@@ -20,9 +20,7 @@ import be.cytomine.common.repository.model.ontology.payload.CreateOntology;
 import be.cytomine.common.repository.model.ontology.payload.OntologyLight;
 import be.cytomine.common.repository.model.ontology.payload.UpdateOntology;
 
-import static be.cytomine.common.repository.http.OntologyHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(OntologyHttpContract.ROOT_PATH)
 public interface OntologyHttpContract {
     String ROOT_PATH = "/ontologies";
 

--- a/common/src/main/java/be/cytomine/common/repository/http/RelationHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/RelationHttpContract.java
@@ -5,10 +5,7 @@ import org.springframework.web.service.annotation.HttpExchange;
 
 import be.cytomine.common.repository.model.command.payload.response.RelationResponse;
 
-import static be.cytomine.common.repository.http.RelationHttpContract.ROOT_PATH;
-
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(RelationHttpContract.ROOT_PATH)
 public interface RelationHttpContract {
     String ROOT_PATH = "/relation";
 

--- a/common/src/main/java/be/cytomine/common/repository/http/ReviewedAnnotationHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/ReviewedAnnotationHttpContract.java
@@ -8,9 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PutExchange;
 
-import static be.cytomine.common.repository.http.ReviewedAnnotationHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(ReviewedAnnotationHttpContract.ROOT_PATH)
 public interface ReviewedAnnotationHttpContract {
     String ROOT_PATH = "/reviewed-annotations";
 
@@ -18,6 +16,4 @@ public interface ReviewedAnnotationHttpContract {
     Set<Long> replaceAllTermIds(@PathVariable long reviewedAnnotationTermsId,
         @RequestParam long userId,
         @RequestBody Set<Long> newLinks);
-
-
 }

--- a/common/src/main/java/be/cytomine/common/repository/http/RoleHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/RoleHttpContract.java
@@ -19,9 +19,7 @@ import be.cytomine.common.repository.model.command.payload.response.RoleResponse
 import be.cytomine.common.repository.model.role.payload.CreateRole;
 import be.cytomine.common.repository.model.role.payload.UpdateRole;
 
-import static be.cytomine.common.repository.http.RoleHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(RoleHttpContract.ROOT_PATH)
 public interface RoleHttpContract {
     String ROOT_PATH = "/roles";
 

--- a/common/src/main/java/be/cytomine/common/repository/http/StatsHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/StatsHttpContract.java
@@ -14,9 +14,7 @@ import be.cytomine.common.repository.model.stat.payload.FlatStatUserTerm;
 import be.cytomine.common.repository.model.stat.payload.StatPerTermAndImage;
 import be.cytomine.common.repository.model.stat.payload.StatTerm;
 
-import static be.cytomine.common.repository.http.StatsHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(StatsHttpContract.ROOT_PATH)
 public interface StatsHttpContract {
     String ROOT_PATH = "/stats";
 

--- a/common/src/main/java/be/cytomine/common/repository/http/StorageHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/StorageHttpContract.java
@@ -19,9 +19,7 @@ import be.cytomine.common.repository.model.command.payload.response.StorageRespo
 import be.cytomine.common.repository.model.storage.payload.CreateStorage;
 import be.cytomine.common.repository.model.storage.payload.UpdateStorage;
 
-import static be.cytomine.common.repository.http.StorageHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(StorageHttpContract.ROOT_PATH)
 public interface StorageHttpContract {
     String ROOT_PATH = "/storages";
 

--- a/common/src/main/java/be/cytomine/common/repository/http/TagDomainAssociationHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/TagDomainAssociationHttpContract.java
@@ -19,9 +19,7 @@ import be.cytomine.common.repository.model.command.payload.response.TagDomainAss
 import be.cytomine.common.repository.model.tagdomainassociation.payload.CreateTagDomainAssociation;
 import be.cytomine.common.repository.model.tagdomainassociation.payload.UpdateTagDomainAssociation;
 
-import static be.cytomine.common.repository.http.TagDomainAssociationHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(TagDomainAssociationHttpContract.ROOT_PATH)
 public interface TagDomainAssociationHttpContract {
     String ROOT_PATH = "/tag-domain-associations";
 

--- a/common/src/main/java/be/cytomine/common/repository/http/TermHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/TermHttpContract.java
@@ -20,9 +20,7 @@ import be.cytomine.common.repository.model.command.payload.response.TermResponse
 import be.cytomine.common.repository.model.term.payload.CreateTerm;
 import be.cytomine.common.repository.model.term.payload.UpdateTerm;
 
-import static be.cytomine.common.repository.http.TermHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(TermHttpContract.ROOT_PATH)
 public interface TermHttpContract {
     String ROOT_PATH = "/terms";
 

--- a/common/src/main/java/be/cytomine/common/repository/http/TermRelationHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/TermRelationHttpContract.java
@@ -19,9 +19,7 @@ import be.cytomine.common.repository.model.command.payload.response.TermRelation
 import be.cytomine.common.repository.model.termrelation.payload.CreateTermRelation;
 import be.cytomine.common.repository.model.termrelation.payload.UpdateTermRelation;
 
-import static be.cytomine.common.repository.http.TermRelationHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(TermRelationHttpContract.ROOT_PATH)
 public interface TermRelationHttpContract {
     String ROOT_PATH = "/term_relations";
 

--- a/common/src/main/java/be/cytomine/common/repository/http/UploadedFileHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/UploadedFileHttpContract.java
@@ -19,9 +19,7 @@ import be.cytomine.common.repository.model.command.payload.response.UploadedFile
 import be.cytomine.common.repository.model.uploadedfile.payload.CreateUploadedFile;
 import be.cytomine.common.repository.model.uploadedfile.payload.UpdateUploadedFile;
 
-import static be.cytomine.common.repository.http.UploadedFileHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(UploadedFileHttpContract.ROOT_PATH)
 public interface UploadedFileHttpContract {
     String ROOT_PATH = "/uploaded-files";
 

--- a/common/src/main/java/be/cytomine/common/repository/http/UserRoleHttpContract.java
+++ b/common/src/main/java/be/cytomine/common/repository/http/UserRoleHttpContract.java
@@ -21,9 +21,7 @@ import be.cytomine.common.repository.model.command.payload.response.UserRoleResp
 import be.cytomine.common.repository.model.userrole.payload.role.payload.CreateUserRole;
 import be.cytomine.common.repository.model.userrole.payload.role.payload.UpdateUserRole;
 
-import static be.cytomine.common.repository.http.UserRoleHttpContract.ROOT_PATH;
-
-@HttpExchange(ROOT_PATH)
+@HttpExchange(UserRoleHttpContract.ROOT_PATH)
 public interface UserRoleHttpContract {
 
     String ROOT_PATH = "/user_roles";

--- a/common/src/main/java/be/cytomine/common/repository/model/command/payload/term/UpdateTermCommandPayload.java
+++ b/common/src/main/java/be/cytomine/common/repository/model/command/payload/term/UpdateTermCommandPayload.java
@@ -1,7 +1,0 @@
-package be.cytomine.common.repository.model.command.payload.term;
-
-import java.util.Optional;
-
-import be.cytomine.common.repository.model.command.payload.request.TermCommandPayload;
-
-public record UpdateTermCommandPayload(Optional<TermCommandPayload> before, Optional<TermCommandPayload> after) {}


### PR DESCRIPTION
To avoid ambiguity when importing `ROOT_PATH`, use the class prefix.