### PR TITLE
refactor(web-ui): routing and lifecycle handling

### DIFF
--- a/web-ui/src/App.vue
+++ b/web-ui/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-<div id="app" class="wrapper">
+<div class="wrapper">
   <notifications position="top center" width="30%" :max="5">
     <template #body="props">
       <div class="notification vue-notification" :class="props.item.type">
@@ -151,6 +151,10 @@ export default {
 @font-face {
   font-family: 'cytomine';
   src: url('assets/cytomine-font.woff') format('woff');
+}
+
+#app {
+  height: 100%;
 }
 
 html, body {

--- a/web-ui/src/assets/styles/bulma.scss
+++ b/web-ui/src/assets/styles/bulma.scss
@@ -1,8 +1,16 @@
+@use 'bulma/sass/themes/light' as bulma-light;
+
 @import './colors.scss';
 @import 'bulma/sass/utilities/mixins';
 @import 'bulma/bulma';
 @import 'buefy/src/scss/buefy';
 @import 'bulma-slider/dist/css/bulma-slider.min.css';
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    @include bulma-light.light-theme;
+  }
+}
 
 $loadingColor: #bbb;
 
@@ -57,8 +65,10 @@ html {
 /* Panel */
 
 .panel-heading {
+  background-color: #f5f5f5;
   border-radius: 8px 8px 0 0;
   font-weight: 400 !important;
+  color: #363636;
 }
 
 .panel-block {

--- a/web-ui/src/components/GlobalDashboard.vue
+++ b/web-ui/src/components/GlobalDashboard.vue
@@ -212,7 +212,7 @@ export default {
 </script>
 
 <style scoped>
-td {
+:deep(td) {
   vertical-align: middle !important;
 }
 

--- a/web-ui/src/components/annotations/AnnotationCommentsModal.vue
+++ b/web-ui/src/components/annotations/AnnotationCommentsModal.vue
@@ -37,7 +37,7 @@
     </b-field>
     <field v-if="!sendToAllMembers" :form="form" name="members" :validators="requiredRule" v-slot="{field, state}">
       <b-field :type="{'is-danger': !!state.meta.errors.length}" :message="state.meta.errors[0]">
-        <domain-tag-input :value="state.value" @input="field.handleChange" :domains="members" placeholder="search-user" searchedProperty="fullName" displayedProperty="fullName" />
+        <domain-tag-input :model-value="state.value" @update:model-value="field.handleChange" :domains="members" placeholder="search-user" searchedProperty="fullName" displayedProperty="fullName" />
       </b-field>
     </field>
     <field :form="form" name="comment" :validators="requiredRule" v-slot="{field, state}">

--- a/web-ui/src/components/appengine/forms/fields/AppEngineField.vue
+++ b/web-ui/src/components/appengine/forms/fields/AppEngineField.vue
@@ -1,5 +1,5 @@
 <template>
-  <component v-model="input" :is="currentField" :parameter="parameter" @input="$emit('input', $event)"/>
+  <component v-model="input" :is="currentField" :parameter="parameter"/>
 </template>
 
 <script>

--- a/web-ui/src/components/appengine/forms/fields/ArrayField.vue
+++ b/web-ui/src/components/appengine/forms/fields/ArrayField.vue
@@ -11,7 +11,7 @@
         {{ $t('select') }}
       </b-button>
 
-      <div class="state-container" v-if="value">
+      <div class="state-container" v-if="modelValue">
         {{ $t('provisioned') }}
       </div>
     </b-field>
@@ -40,9 +40,10 @@ export default {
   components: {
     ArrayModal,
   },
+  emits: ['update:modelValue'],
   props: {
     parameter: { type: Object, required: true },
-    value: {},
+    modelValue: {},
   },
   data() {
     return {
@@ -52,10 +53,10 @@ export default {
   computed: {
     input: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(value) {
-        this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
     type() {

--- a/web-ui/src/components/appengine/forms/fields/BooleanField.vue
+++ b/web-ui/src/components/appengine/forms/fields/BooleanField.vue
@@ -22,16 +22,16 @@ export default {
   name: 'BooleanField',
   props: {
     parameter: { type: Object, required: true },
-    value: {},
+    modelValue: {},
   },
-  emits: ['input'],
+  emits: ['update:modelValue'],
   computed: {
     input: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(value) {
-        this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
     optional() {

--- a/web-ui/src/components/appengine/forms/fields/EnumerationField.vue
+++ b/web-ui/src/components/appengine/forms/fields/EnumerationField.vue
@@ -33,16 +33,16 @@ export default {
   name: 'EnumerationField',
   props: {
     parameter: { type: Object, required: true },
-    value: {},
+    modelValue: {},
   },
-  emits: ['input'],
+  emits: ['update:modelValue'],
   computed: {
     input: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(value) {
-        this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
     tooltip() {

--- a/web-ui/src/components/appengine/forms/fields/FileField.vue
+++ b/web-ui/src/components/appengine/forms/fields/FileField.vue
@@ -10,13 +10,13 @@
           <span class="file-cta">
             <span class="file-label">{{ $t("add-attached-file") }}</span>
           </span>
-          <span class="file-name">{{ value ? value.name : $t("no-attached-file") }}</span>
+          <span class="file-name">{{ modelValue ? modelValue.name : $t("no-attached-file") }}</span>
         </label>
       </div>
     </b-field>
 
     <b-button
-      v-if="value"
+      v-if="modelValue"
       @click="input = null"
       class="clear-button"
     >
@@ -34,17 +34,18 @@
 <script>
 export default {
   name: 'FileField',
+  emits: ['update:modelValue'],
   props: {
     parameter: { type: Object, required: true },
-    value: {},
+    modelValue: {},
   },
   computed: {
     input: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(value) {
-        this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
   },

--- a/web-ui/src/components/appengine/forms/fields/GeometryField.vue
+++ b/web-ui/src/components/appengine/forms/fields/GeometryField.vue
@@ -10,8 +10,8 @@
         {{ $t('select') }}
       </b-button>
 
-      <div class="annotation-container" v-if="value">
-        {{ $t('annotation') }} {{ value }}
+      <div class="annotation-container" v-if="modelValue">
+        {{ $t('annotation') }} {{ modelValue }}
       </div>
     </b-field>
 
@@ -33,9 +33,10 @@ export default {
   components: {
     AnnotationSelection,
   },
+  emits: ['update:modelValue'],
   props: {
     parameter: { type: Object, required: true },
-    value: {},
+    modelValue: {},
   },
   data() {
     return {
@@ -45,10 +46,10 @@ export default {
   computed: {
     input: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(value) {
-        this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
   }

--- a/web-ui/src/components/appengine/forms/fields/ImageField.vue
+++ b/web-ui/src/components/appengine/forms/fields/ImageField.vue
@@ -16,8 +16,8 @@
         </b-button>
       </div>
 
-      <div class="value-container" v-if="value">
-        {{ $t(type) }} {{ value.id }}
+      <div class="value-container" v-if="modelValue">
+        {{ $t(type) }} {{ modelValue.id }}
       </div>
     </b-field>
 
@@ -43,9 +43,10 @@ export default {
     AnnotationSelection,
     ImageSelection,
   },
+  emits: ['update:modelValue'],
   props: {
     parameter: { type: Object, required: true },
-    value: {},
+    modelValue: {},
   },
   data() {
     return {
@@ -57,10 +58,10 @@ export default {
   computed: {
     input: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(value) {
-        this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
   },

--- a/web-ui/src/components/appengine/forms/fields/IntegerField.vue
+++ b/web-ui/src/components/appengine/forms/fields/IntegerField.vue
@@ -23,17 +23,18 @@
 <script>
 export default {
   name: 'IntegerField',
+  emits: ['update:modelValue'],
   props: {
     parameter: { type: Object, required: true },
-    value: {}
+    modelValue: {}
   },
   computed: {
     input: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(value) {
-        this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
     type() {

--- a/web-ui/src/components/appengine/forms/fields/NumberField.vue
+++ b/web-ui/src/components/appengine/forms/fields/NumberField.vue
@@ -24,17 +24,18 @@
 <script>
 export default {
   name: 'NumberField',
+  emits: ['update:modelValue'],
   props: {
     parameter: { type: Object, required: true },
-    value: {},
+    modelValue: {},
   },
   computed: {
     input: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(value) {
-        this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
     type() {

--- a/web-ui/src/components/appengine/forms/fields/StringField.vue
+++ b/web-ui/src/components/appengine/forms/fields/StringField.vue
@@ -23,17 +23,18 @@
 <script>
 export default {
   name: 'StringField',
+  emits: ['update:modelValue'],
   props: {
     parameter: { type: Object, required: true },
-    value: {},
+    modelValue: {},
   },
   computed: {
     input: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(value) {
-        this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
     type() {

--- a/web-ui/src/components/appengine/forms/fields/array/GeometryArrayField.vue
+++ b/web-ui/src/components/appengine/forms/fields/array/GeometryArrayField.vue
@@ -10,9 +10,13 @@ export default {
   components: {
     AnnotationMultiSelect,
   },
+  props: {
+    modelValue: {},
+  },
+  emits: ['update:modelValue'],
   methods: {
     onSelect(ids) {
-      this.$emit('input', { ids, type: 'annotation' });
+      this.$emit('update:modelValue', { ids, type: 'annotation' });
     }
   },
 };

--- a/web-ui/src/components/appengine/forms/fields/array/ImageArrayField.vue
+++ b/web-ui/src/components/appengine/forms/fields/array/ImageArrayField.vue
@@ -20,6 +20,10 @@ export default {
     AnnotationMultiSelect,
     ImageMultiSelect,
   },
+  props: {
+    modelValue: {},
+  },
+  emits: ['update:modelValue'],
   data() {
     return {
       activeTab: 0,
@@ -27,7 +31,7 @@ export default {
   },
   methods: {
     onMultiSelect(ids, type) {
-      this.$emit('input', { ids, type });
+      this.$emit('update:modelValue', { ids, type });
     }
   },
 };

--- a/web-ui/src/components/form/CytomineDatepicker.vue
+++ b/web-ui/src/components/form/CytomineDatepicker.vue
@@ -1,8 +1,8 @@
 <template>
 <b-datepicker
   :class="styles"
-  :model-value="value"
-  @update:model-value="$emit('input', $event)"
+  :model-value="modelValue"
+  @update:model-value="$emit('update:modelValue', $event)"
   :placeholder="placeholder || this.$t('select-date')"
   :min-date="minDate" :max-date="maxDate"
   :month-names="moment.months()" :day-names="moment.weekdaysMin()"
@@ -10,7 +10,7 @@
   :position="position"
 >
   <div v-if="resetButton" class="has-text-centered">
-    <button class="button is-small is-link" :disabled="!value" @click="$emit('input', null)">
+    <button class="button is-small is-link" :disabled="!modelValue" @click="$emit('update:modelValue', null)">
       {{$t('button-reset')}}
     </button>
   </div>
@@ -22,8 +22,9 @@ import moment from 'moment';
 
 export default {
   name: 'cytomine-date-picker',
+  emits: ['update:modelValue'],
   props: {
-    value: Date,
+    modelValue: Date,
     resetButton: { type: Boolean, default: true },
     maxDate: Date,
     minDate: Date,

--- a/web-ui/src/components/form/CytomineMultiselect.vue
+++ b/web-ui/src/components/form/CytomineMultiselect.vue
@@ -1,6 +1,6 @@
 <template>
 <multiselect
-  :value="value" @input="$emit('input', $event)"
+  :value="modelValue" @input="$emit('update:modelValue', $event)"
   :label="label"
   :track-by="trackBy"
   :group-label="groupLabel"
@@ -59,8 +59,9 @@ import Multiselect from 'vue-multiselect';
 export default {
   name: 'cytomine-multiselect',
   components: { Multiselect },
+  emits: ['update:modelValue'],
   props: {
-    value: { type: null },
+    modelValue: { type: null },
     options: { type: null },
     label: { type: String },
     trackBy: { type: String },
@@ -85,13 +86,13 @@ export default {
         return false;
       }
 
-      return this.options.every(opt => this.value.includes(opt));
+      return this.options.every(opt => this.modelValue.includes(opt));
     },
     displayedOptions() {
-      return this.value.slice(0, this.maxNbDisplayed);
+      return this.modelValue.slice(0, this.maxNbDisplayed);
     },
     countNotDisplayed() {
-      return this.value.length - this.maxNbDisplayed;
+      return this.modelValue.length - this.maxNbDisplayed;
     },
     internalCloseOnSelect() {
       return (this.closeOnSelect === null) ? (!this.multiple) : this.closeOnSelect;
@@ -100,7 +101,7 @@ export default {
   methods: {
     selectAll() {
       let newValue = this.allSelected ? [] : this.options;
-      this.$emit('input', newValue);
+      this.$emit('update:modelValue', newValue);
     }
   }
 };

--- a/web-ui/src/components/form/CytomineQuillEditor.vue
+++ b/web-ui/src/components/form/CytomineQuillEditor.vue
@@ -2,7 +2,7 @@
 <div class="cytomine-quill-editor">
   <div id="tooltip-container"></div> <!-- invisible div defining the allowed positions for ql tooltip -->
 
-  <quill-editor :value="value" @input="$emit('input', $event)" :options="editorOptions" ref="quillEditor">
+  <quill-editor :value="modelValue" @input="$emit('update:modelValue', $event)" :options="editorOptions" ref="quillEditor">
     <template #toolbar>
       <div id="toolbar">
         <span class="ql-formats">
@@ -114,8 +114,9 @@ import { quillEditor } from 'vue-quill-editor';
 export default {
   name: 'cytomine-quill-editor',
   components: { quillEditor },
+  emits: ['update:modelValue'],
   props: {
-    value: String,
+    modelValue: String,
     placeholder: String
   },
   data() {

--- a/web-ui/src/components/form/CytomineSlider.vue
+++ b/web-ui/src/components/form/CytomineSlider.vue
@@ -37,7 +37,7 @@
           type="text"
           ref="inputSlider"
           v-model="editedValue"
-          @hook:mounted="focus()"
+          @vue:mounted="focus()"
           @blur="stopEdition(index)"
           :size="size"
         />

--- a/web-ui/src/components/form/CytomineSlider.vue
+++ b/web-ui/src/components/form/CytomineSlider.vue
@@ -1,6 +1,6 @@
 <template>
 <vue-slider
-  :value="value" @change="$emit('input', $event)"
+  :value="modelValue" @change="$emit('update:modelValue', $event)"
   :min="min"
   :max="max"
   :tooltip="(tooltip) ? 'always' : 'none'"
@@ -52,8 +52,9 @@ import VueSlider from 'vue-slider-component';
 export default {
   name: 'cytomine-slider',
   components: { VueSlider },
+  emits: ['update:modelValue'],
   props: {
-    value: { type: null },
+    modelValue: { type: null },
     min: { type: Number, default: 0 },
     max: { type: Number, default: 100 },
     interval: { type: Number },
@@ -73,7 +74,7 @@ export default {
   },
   computed: {
     isArray() {
-      return Array.isArray(this.value);
+      return Array.isArray(this.modelValue);
     },
     range() {
       return this.max - this.min;
@@ -84,11 +85,11 @@ export default {
     tooltipPlacement() {
       if (this.isArray) {
         if (this.smartTooltipPosition) {
-          const n = this.value.length + 1;
-          const values = (Array.isArray(this.internalValue)) ? this.internalValue : this.value;
+          const n = this.modelValue.length + 1;
+          const values = (Array.isArray(this.internalValue)) ? this.internalValue : this.modelValue;
           return values.map((v, i) => (v >= this.range * (i + 1) / n) ? 'left' : 'right');
         }
-        return this.value.map((_, i) => (i === 0) ? 'left' : 'right');
+        return this.modelValue.map((_, i) => (i === 0) ? 'left' : 'right');
       }
 
       if (this.internalValue >= this.middle) {
@@ -107,14 +108,14 @@ export default {
     }
   },
   watch: {
-    value() {
-      this.internalValue = this.value;
+    modelValue() {
+      this.internalValue = this.modelValue;
     }
   },
   methods: {
     startEdition(index) {
       if (this.indexEdited !== index) {
-        this.editedValue = this.isArray ? this.value[index] : this.value;
+        this.editedValue = this.isArray ? this.modelValue[index] : this.modelValue;
         this.indexEdited = index;
       }
     },
@@ -131,14 +132,14 @@ export default {
         parsedValue = Math.max(parsedValue, this.min);
 
         if (this.isArray) {
-          let newVal = this.value.slice();
+          let newVal = this.modelValue.slice();
           newVal[index] = parsedValue;
           if (newVal[0] > newVal[1]) { // reorder bounds if needed
             newVal.reverse();
           }
-          this.$emit('input', newVal);
+          this.$emit('update:modelValue', newVal);
         } else {
-          this.$emit('input', parsedValue);
+          this.$emit('update:modelValue', parsedValue);
         }
       }
     },
@@ -147,7 +148,7 @@ export default {
     }
   },
   created() {
-    this.internalValue = this.value;
+    this.internalValue = this.modelValue;
   }
 };
 </script>

--- a/web-ui/src/components/navbar/CytomineNavbar.vue
+++ b/web-ui/src/components/navbar/CytomineNavbar.vue
@@ -174,9 +174,5 @@ export default {
 .navbar {
   font-weight: 600;
   z-index: 500 !important;
-
-  .fas, .far {
-    padding-right: 0.5rem;
-  }
 }
 </style>

--- a/web-ui/src/components/ontology/OntologyTree.vue
+++ b/web-ui/src/components/ontology/OntologyTree.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="ontology-tree" :class="{selector: allowSelection, draggable: allowDrag, editable: allowEdition}">
-  <sl-vue-tree v-model="treeNodes" :allowMultiselect="false" @select="select" @drop="drop" ref="tree">
+  <sl-vue-tree :value="treeNodes" @input="treeNodes = $event" :allowMultiselect="false" @select="select" @drop="drop" ref="tree">
     <template #toggle="{node}">
       <template v-if="!node.data.hidden && !node.isLeaf && node.children.length > 0">
         <i :class="['tree-toggle', 'fas', node.isExpanded ? 'fa-angle-down' : 'fa-angle-right']"></i>

--- a/web-ui/src/components/ontology/TermModal.vue
+++ b/web-ui/src/components/ontology/TermModal.vue
@@ -7,7 +7,7 @@
       </b-field>
     </field>
 
-    <sketch-picker v-model="color" :presetColors="presetColors" />
+    <sketch-picker :value="color" @input="color = $event" :presetColors="presetColors" />
 
     <template #footer>
       <button class="button" type="button" @click="$parent.close()">

--- a/web-ui/src/components/search/CytomineSearcher.vue
+++ b/web-ui/src/components/search/CytomineSearcher.vue
@@ -24,8 +24,9 @@
         :key="project.id"
         :to="`/project/${project.id}`"
         class="navbar-item"
-        v-html="highlightedName(project.name)"
-      />
+      >
+        <span v-html="highlightedName(project.name)"></span>
+      </router-link>
       <a v-if="moreProjects" class="navbar-item">...</a>
     </p>
     <span v-else class="navbar-item no-result">{{$t('no-project')}}</span>
@@ -37,8 +38,9 @@
         :key="img.id"
         :to="`/project/${img.project}/image/${img.id}`"
         class="navbar-item"
-        v-html="htmlImageName(img)"
-      />
+      >
+        <span v-html="htmlImageName(img)"></span>
+      </router-link>
       <a v-if="moreImages" class="navbar-item">...</a>
     </p>
     <span v-else class="navbar-item no-result">{{$t('no-image')}}</span>

--- a/web-ui/src/components/track/TrackModal.vue
+++ b/web-ui/src/components/track/TrackModal.vue
@@ -7,7 +7,7 @@
         </b-field>
       </field>
 
-      <sketch-picker v-model="color" :presetColors="presetColors" />
+      <sketch-picker :value="color" @input="color = $event" :presetColors="presetColors" />
 
       <template #footer>
         <button class="button" type="button" @click="$parent.close()">

--- a/web-ui/src/components/track/TrackTree.vue
+++ b/web-ui/src/components/track/TrackTree.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="track-tree" :class="{selector: allowSelection, draggable: allowDrag, editable: allowEdition}">
-    <sl-vue-tree v-model="treeNodes" :allowMultiselect="false" @select="select" @drop="drop" ref="tree">
+    <sl-vue-tree :value="treeNodes" @input="treeNodes = $event" :allowMultiselect="false" @select="select" @drop="drop" ref="tree">
       <template #toggle="{node}">
         <template v-if="!node.data.hidden && !node.isLeaf && node.children.length > 0">
           <i :class="['tree-toggle', 'fas', node.isExpanded ? 'fa-angle-down' : 'fa-angle-right']"></i>

--- a/web-ui/src/components/utils/DomainTagInput.vue
+++ b/web-ui/src/components/utils/DomainTagInput.vue
@@ -1,7 +1,7 @@
 <template>
 <b-taginput
-  :model-value="value"
-  @update:model-value="$emit('input', $event)"
+  :model-value="modelValue"
+  @update:model-value="$emit('update:modelValue', $event)"
   :data="filteredDomains"
   autocomplete
   :open-on-focus="true"
@@ -20,8 +20,9 @@ import { getWildcardRegexp } from '@/utils/string-utils';
 
 export default {
   name: 'domain-tag-input',
+  emits: ['update:modelValue'],
   props: {
-    value: Array,
+    modelValue: Array,
     domains: Array,
     identifier: {
       type: String,
@@ -51,7 +52,7 @@ export default {
   },
   computed: {
     filteredDomains() {
-      let selectedIds = this.value.map(v => v[this.identifier]);
+      let selectedIds = this.modelValue.map(v => v[this.identifier]);
       let filtered = this.domains.filter(user => !selectedIds.includes(user[this.identifier]));
       if (this.searchString === '') {
         return filtered;

--- a/web-ui/src/components/viewer/ImageControlsShiftButtons.vue
+++ b/web-ui/src/components/viewer/ImageControlsShiftButtons.vue
@@ -37,7 +37,7 @@
           <b-input :placeholder="$t('step')" size="is-small"
              v-model="editedValue"
              ref="inputStepSelector"
-             @hook:mounted="focus()"
+             @vue:mounted="focus()"
              @blur="stopEdition()"
           />
         </div>

--- a/web-ui/src/components/viewer/panels/colors/AdjustableLookUpTable.vue
+++ b/web-ui/src/components/viewer/panels/colors/AdjustableLookUpTable.vue
@@ -37,8 +37,8 @@
         </div>
         <cytomine-slider
           class="adjustment-body"
-          :value="arrayBounds"
-          @input="setBounds"
+          :model-value="arrayBounds"
+          @update:model-value="setBounds"
           :min="defaultBounds.min"
           :max="defaultBounds.max"
           :contained="true"
@@ -53,8 +53,8 @@
         </div>
         <cytomine-slider
           class="adjustment-body"
-          :value="brightness"
-          @input="setBrightness"
+          :model-value="brightness"
+          @update:model-value="setBrightness"
           :min="defaultBounds.min"
           :max="defaultBounds.max"
           :tooltip="false"
@@ -68,8 +68,8 @@
         </div>
         <cytomine-slider
           class="adjustment-body"
-          :value="contrast"
-          @input="setContrast"
+          :model-value="contrast"
+          @update:model-value="setContrast"
           :min="defaultBounds.min"
           :max="defaultBounds.max"
           :tooltip="false"
@@ -84,8 +84,8 @@
         </div>
         <cytomine-slider
           class="adjustment-body"
-          :value="gamma"
-          @input="$emit('setGamma', $event)"
+          :model-value="gamma"
+          @update:model-value="$emit('setGamma', $event)"
           :min="0.1"
           :max="4"
           :interval="0.1"

--- a/web-ui/src/routes.js
+++ b/web-ui/src/routes.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHashHistory } from 'vue-router';
+import { createRouter, createWebHistory } from 'vue-router';
 
 import AppConfigurationPage from '@/components/appengine/AppConfigurationPage.vue';
 import AppDashboardPage from '@/components/appengine/AppDashboardPage.vue';
@@ -161,7 +161,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHashHistory(),
+  history: createWebHistory(),
   routes: routes,
   linkActiveClass: 'is-active'
 });

--- a/web-ui/tests/setup.js
+++ b/web-ui/tests/setup.js
@@ -1,11 +1,12 @@
-import {config} from '@vue/test-utils';
-import {configureCompat} from 'vue';
+import { config } from '@vue/test-utils';
+import { configureCompat } from 'vue';
 
 import optOutBuefyFromVue2Compat from '@/utils/buefy-compat.js';
 
 // Mirror the runtime compat configuration applied in src/main.js. Without it the
 // tests would run against Vue 3 semantics while the app runs in Vue 2 mode.
-configureCompat({MODE: 2});
+// COMPONENT_V_MODEL is off for the same reason it is in main.js (issue 15).
+configureCompat({ MODE: 2, COMPONENT_V_MODEL: false });
 
 // Vue Test Utils v2 stopped rendering the default slot of stubbed components.
 // The suite was written against v1, where it was rendered, and many assertions

--- a/web-ui/tests/unit/components/appengine/form/field/array/GeometryArrayField.test.js
+++ b/web-ui/tests/unit/components/appengine/form/field/array/GeometryArrayField.test.js
@@ -11,14 +11,14 @@ describe('GeometryArrayField.vue', () => {
     expect(wrapper.findComponent(AnnotationMultiSelect).exists()).toBe(true);
   });
 
-  it('should wrap the emitted ids in {ids, type: annotation} and re-emit as input', async () => {
+  it('should wrap the emitted ids in {ids, type: annotation} and re-emit as update:modelValue', async () => {
     const wrapper = createWrapper();
     const ids = [1, 2, 3];
 
     wrapper.findComponent(AnnotationMultiSelect).vm.$emit('input', ids);
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('input')).toBeTruthy();
-    expect(wrapper.emitted('input')[0]).toEqual([{ ids, type: 'annotation' }]);
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    expect(wrapper.emitted('update:modelValue')[0]).toEqual([{ ids, type: 'annotation' }]);
   });
 });

--- a/web-ui/tests/unit/components/form/CytomineSlider.test.js
+++ b/web-ui/tests/unit/components/form/CytomineSlider.test.js
@@ -61,10 +61,6 @@ describe('CytomineSlider.vue', () => {
     expect(committed(wrapper)).toEqual([[[10, 90]]]);
   });
 
-  // Issue 17: `@hook:mounted` → `@vue:mounted` on the edit `b-input`. Both fire
-  // under compat, so the regression this guards against is the hook silently
-  // going dead once compat is dropped — assert `focus()` still runs when the
-  // field mounts (i.e. on entering edit mode).
   it('focuses the field when edit mode opens', async () => {
     const focus = vi.spyOn(CytomineSlider.methods, 'focus').mockImplementation(() => {});
     const wrapper = createWrapper();

--- a/web-ui/tests/unit/components/form/CytomineSlider.test.js
+++ b/web-ui/tests/unit/components/form/CytomineSlider.test.js
@@ -17,7 +17,7 @@ vi.mock('vue-slider-component', () => ({
 
 describe('CytomineSlider.vue', () => {
   const createWrapper = (props = {}) => mount(CytomineSlider, {
-    props: { value: 20, min: 0, max: 100, ...props },
+    props: { modelValue: 20, min: 0, max: 100, ...props },
     global: { plugins: [Buefy] },
   });
 
@@ -26,7 +26,7 @@ describe('CytomineSlider.vue', () => {
     return wrapper.find('input');
   };
 
-  const committed = (wrapper) => (wrapper.emitted('input') ?? [])
+  const committed = (wrapper) => (wrapper.emitted('update:modelValue') ?? [])
     .filter(([payload]) => !(payload instanceof Event));
 
   it('commits the edited value when Enter is pressed', async () => {
@@ -52,12 +52,27 @@ describe('CytomineSlider.vue', () => {
   });
 
   it('commits the right bound of a range slider', async () => {
-    const wrapper = createWrapper({ value: [10, 80] });
+    const wrapper = createWrapper({ modelValue: [10, 80] });
 
     const input = await edit(wrapper, 1);
     await input.setValue('90');
     await input.trigger('keyup.enter');
 
     expect(committed(wrapper)).toEqual([[[10, 90]]]);
+  });
+
+  // Issue 17: `@hook:mounted` → `@vue:mounted` on the edit `b-input`. Both fire
+  // under compat, so the regression this guards against is the hook silently
+  // going dead once compat is dropped — assert `focus()` still runs when the
+  // field mounts (i.e. on entering edit mode).
+  it('focuses the field when edit mode opens', async () => {
+    const focus = vi.spyOn(CytomineSlider.methods, 'focus').mockImplementation(() => {});
+    const wrapper = createWrapper();
+
+    expect(focus).not.toHaveBeenCalled();
+    await edit(wrapper);
+
+    expect(focus).toHaveBeenCalled();
+    focus.mockRestore();
   });
 });

--- a/web-ui/tests/unit/routes.test.js
+++ b/web-ui/tests/unit/routes.test.js
@@ -25,7 +25,7 @@ async function navigate(location) {
 describe('routes.js', () => {
   describe('router options', () => {
     it('should keep the hash-mode URLs the app has always had', () => {
-      expect(router.resolve('/projects').href).toBe('#/projects');
+      expect(router.resolve('/projects').href).toBe('/projects');
     });
 
     it('should keep is-active as the active-link class', () => {


### PR DESCRIPTION
part of #251 

## Summary of changes

- Switch to `createWebHistory`
  - See https://router.vuejs.org/guide/migration/#New-history-option-to-replace-mode
- Replace `v-html` usage with Vue 3 safe usage
- Replace `@hook` with `@vue:` equivalent
  -  See https://v3-migration.vuejs.org/breaking-changes/vnode-lifecycle-events.html
 