### PR TITLE
refactor(web-ui): access keycloak via getter instead

### DIFF
--- a/web-ui/src/components/admin/AdminPanel.vue
+++ b/web-ui/src/components/admin/AdminPanel.vue
@@ -29,6 +29,7 @@
 <script>
 import { get } from '@/utils/store-helpers';
 import { KeycloakRole } from '@/constants/UserRole.js';
+import { getKeycloak } from '@/keycloak.js';
 
 import AdminDashboard from './AdminDashboard.vue';
 import AdminUsers from './AdminUsers.vue';
@@ -54,7 +55,7 @@ export default {
       return this.$route.query.tab;
     },
     isAdmin() {
-      return this.$keycloak.hasResourceRole(KeycloakRole.ADMIN);
+      return getKeycloak().hasResourceRole(KeycloakRole.ADMIN);
     },
     activeComponent() {
       switch (this.activeTab) {

--- a/web-ui/src/components/navbar/CytomineNavbar.vue
+++ b/web-ui/src/components/navbar/CytomineNavbar.vue
@@ -88,6 +88,7 @@ import CytomineSearcher from '@/components/search/CytomineSearcher.vue';
 import constants from '@/utils/constants.js';
 import shortcuts from '@/utils/shortcuts.js';
 import { KeycloakRole } from '@/constants/UserRole.js';
+import { getKeycloak } from '@/keycloak.js';
 
 export default {
   name: 'cytomine-navbar',
@@ -107,7 +108,7 @@ export default {
   computed: {
     currentUser: get('currentUser/user'),
     isAdmin() {
-      return this.$keycloak.hasResourceRole(KeycloakRole.ADMIN);
+      return getKeycloak().hasResourceRole(KeycloakRole.ADMIN);
     },
     nbActiveProjects() {
       return Object.keys(this.$store.state.projects).length;
@@ -144,7 +145,7 @@ export default {
       try {
         this.$store.dispatch('logout');
         this.changeLanguage();
-        await this.$keycloak.logout();
+        await getKeycloak().logout();
       } catch (error) {
         console.log(error);
         this.$notify({ type: 'error', text: this.$t('notif-error-logout') });

--- a/web-ui/src/components/user/Account.vue
+++ b/web-ui/src/components/user/Account.vue
@@ -163,6 +163,7 @@ import { MyAccount, User } from '@/api';
 import { email, required, rules, validateForm } from '@/utils/form.js';
 import { rolesMapping } from '@/utils/role-utils';
 import { KeycloakRole, UserRole } from '@/constants/UserRole.js';
+import { getKeycloak } from '@/keycloak.js';
 import copyToClipboard from 'copy-to-clipboard';
 import { formatMomentDate } from '@/utils/date';
 
@@ -201,8 +202,8 @@ export default {
     currentAccount: get('currentUser/account'),
     role() {
       // Guest > User > Admin
-      let key = this.$keycloak.hasResourceRole(KeycloakRole.ADMIN) ? UserRole.ADMIN
-        : this.$keycloak.hasResourceRole(KeycloakRole.USER) ? UserRole.USER : UserRole.GUEST;
+      let key = getKeycloak().hasResourceRole(KeycloakRole.ADMIN) ? UserRole.ADMIN
+        : getKeycloak().hasResourceRole(KeycloakRole.USER) ? UserRole.USER : UserRole.GUEST;
       return rolesMapping[key];
     },
 
@@ -239,7 +240,7 @@ export default {
     },
 
     updatePassword() {
-      this.$keycloak.login({ action: this.passwordCredentials.updateAction });
+      getKeycloak().login({ action: this.passwordCredentials.updateAction });
     },
 
 

--- a/web-ui/src/keycloak.js
+++ b/web-ui/src/keycloak.js
@@ -3,7 +3,7 @@ import constants from './utils/constants';
 
 let _keycloak = null;
 
-function getKeycloak() {
+export function getKeycloak() {
   if (!_keycloak) {
     // Strip /realms/cytomine if present, as Keycloak JS adds it automatically
     let url = constants.IAM_URL;
@@ -23,22 +23,3 @@ function getKeycloak() {
   }
   return _keycloak;
 }
-
-const plugin = {
-  install: Vue => {
-    Object.defineProperty(Vue, '$keycloak', {
-      get() {
-        return getKeycloak();
-      }
-    });
-    Object.defineProperties(Vue.prototype, {
-      $keycloak: {
-        get() {
-          return getKeycloak();
-        },
-      },
-    });
-  },
-};
-
-export default plugin;

--- a/web-ui/src/main.js
+++ b/web-ui/src/main.js
@@ -1,6 +1,7 @@
 import Vue, { createApp } from 'vue';
 import axios from 'axios';
 import constants from '@/utils/constants.js';
+import { getKeycloak } from './keycloak.js';
 
 Vue.configureCompat({ MODE: 2, COMPONENT_V_MODEL: false }); // TODO: remove when migration is done
 
@@ -51,23 +52,15 @@ axios.get('configuration.json').then(response => {
     }
   }
 
-  // Now import and initialize Keycloak with loaded config
-  import('./keycloak').then(module => {
-    const Keycloak = module.default;
-    Vue.use(Keycloak);
+  const keycloak = getKeycloak();
 
-    Vue.$keycloak
-      .init({
-        onLoad: 'login-required'
-      })
-      .then(() => {
-        const app = createApp(App);
-        app.use(i18n);
-        app.use(router);
-        app.use(store);
-        app.use(Buefy, { defaultIconPack: 'fas' });
-        app.use(Notifications);
-        app.mount('#app');
-      });
+  keycloak.init({ onLoad: 'login-required' }).then(() => {
+    const app = createApp(App);
+    app.use(i18n);
+    app.use(router);
+    app.use(store);
+    app.use(Buefy, { defaultIconPack: 'fas' });
+    app.use(Notifications);
+    app.mount('#app');
   });
 });

--- a/web-ui/src/utils/token-utils.js
+++ b/web-ui/src/utils/token-utils.js
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import { getKeycloak } from '../keycloak.js';
 
 export function appendShortTermToken(url, shortTermToken) {
   if (url === null || shortTermToken === null) {
@@ -12,6 +12,7 @@ export function appendShortTermToken(url, shortTermToken) {
 }
 
 export async function updateToken(minValidity = 70) {
-  await Vue.$keycloak.updateToken(minValidity);
-  return Vue.$keycloak.token;
+  const keycloak = getKeycloak();
+  await keycloak.updateToken(minValidity);
+  return keycloak.token;
 }

--- a/web-ui/tests/unit/components/navbar/CytomineNavbar.test.js
+++ b/web-ui/tests/unit/components/navbar/CytomineNavbar.test.js
@@ -3,6 +3,17 @@ import Vuex from 'vuex';
 
 import CytomineNavbar from '@/components/navbar/CytomineNavbar';
 
+const { keycloak } = vi.hoisted(() => ({
+  keycloak: {
+    hasResourceRole: vi.fn(() => false),
+    logout: vi.fn().mockResolvedValue()
+  }
+}));
+
+vi.mock('@/keycloak.js', () => ({
+  getKeycloak: () => keycloak
+}));
+
 vi.mock('@/lang.js', () => ({
   changeLanguageMixin: {
     methods: {
@@ -14,11 +25,6 @@ vi.mock('@/lang.js', () => ({
 describe('CytomineNavbar.vue', () => {
   const actions = {
     logout: vi.fn()
-  };
-
-  const keycloak = {
-    hasResourceRole: vi.fn(() => false),
-    logout: vi.fn().mockResolvedValue()
   };
 
   const createWrapper = ({ user = {}, projects = {} } = {}) => {
@@ -46,7 +52,6 @@ describe('CytomineNavbar.vue', () => {
         },
         mocks: {
           $t: (message) => message,
-          $keycloak: keycloak,
           $notify: vi.fn()
         },
         stubs: {


### PR DESCRIPTION
part of #251 

## Summary of changes

Drop the Vue plugin that exposed $keycloak on globalProperties and have all consumers import getKeycloak() directly.

Also `Vue.prototype` is deprecated.
See https://v3-migration.vuejs.org/breaking-changes/global-api.html#vue-prototype-replaced-by-config-globalproperties