### PR TITLE
feat(meilisearch): index at first startup

### DIFF
--- a/core/src/main/java/be/cytomine/service/MeiliSearchService.java
+++ b/core/src/main/java/be/cytomine/service/MeiliSearchService.java
@@ -10,6 +10,7 @@ import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.SearchRequest;
 import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.Searchable;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +30,21 @@ public class MeiliSearchService {
 
     private final Client meiliSearchClient;
     private final ObjectMapper objectMapper;
+
+    @PostConstruct
+    public void createIndexIfNotExists() {
+        try {
+            for (Index index : meiliSearchClient.getIndexes().getResults()) {
+                if (indexId.equals(index.getUid())) {
+                    return;
+                }
+            }
+            meiliSearchClient.createIndex(indexId);
+            log.info("Created MeiliSearch index '{}'", indexId);
+        } catch (Exception e) {
+            log.warn("Could not create MeiliSearch index '{}' at startup: {}", indexId, e.getMessage());
+        }
+    }
 
     public List<MeiliSearchImageResponse> search(
         String query,
@@ -139,5 +155,4 @@ public class MeiliSearchService {
 
         return trimmed;
     }
-
 }

--- a/core/src/test/java/be/cytomine/service/MeiliSearchServiceTest.java
+++ b/core/src/test/java/be/cytomine/service/MeiliSearchServiceTest.java
@@ -1,0 +1,71 @@
+package be.cytomine.service;
+
+import com.meilisearch.sdk.Client;
+import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.model.Results;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MeiliSearchServiceTest {
+
+    private static final String INDEX_ID = "test_index";
+
+    @Mock
+    private Client meiliSearchClient;
+
+    @InjectMocks
+    private MeiliSearchService meiliSearchService;
+
+    @BeforeEach
+    public void setUp() {
+        ReflectionTestUtils.setField(meiliSearchService, "indexId", INDEX_ID);
+    }
+
+    private void mockExistingIndexes(Index... indexes) {
+        Results<Index> results = mock();
+        when(results.getResults()).thenReturn(indexes);
+        when(meiliSearchClient.getIndexes()).thenReturn(results);
+    }
+
+    @Test
+    public void createIndexIfNotExistsShouldCreateIndexWhenMissing() {
+        mockExistingIndexes();
+
+        meiliSearchService.createIndexIfNotExists();
+
+        verify(meiliSearchClient, times(1)).createIndex(INDEX_ID);
+    }
+
+    @Test
+    public void createIndexIfNotExistsShouldNotCreateIndexWhenAlreadyPresent() {
+        Index existing = mock(Index.class);
+        when(existing.getUid()).thenReturn(INDEX_ID);
+        mockExistingIndexes(existing);
+
+        meiliSearchService.createIndexIfNotExists();
+
+        verify(meiliSearchClient, never()).createIndex(INDEX_ID);
+    }
+
+    @Test
+    public void createIndexIfNotExistsShouldSwallowFailures() {
+        when(meiliSearchClient.getIndexes()).thenThrow(new RuntimeException("MeiliSearch unreachable"));
+
+        assertDoesNotThrow(() -> meiliSearchService.createIndexIfNotExists());
+
+        verify(meiliSearchClient, never()).createIndex(INDEX_ID);
+    }
+}


### PR DESCRIPTION
part of #463

Instead of throwing 404 at first startup, add the index to meilisearch to return empty facets.