### PR TITLE
refactor(web-ui): access keycloak via getter instead of Vue plugin

### DIFF
--- a/web-ui/src/components/admin/AdminPanel.vue
+++ b/web-ui/src/components/admin/AdminPanel.vue
@@ -28,6 +28,7 @@
 
 <script>
 import { get } from '@/utils/store-helpers';
+import { getKeycloak } from '@/keycloak.js';
 import { KeycloakRole } from '@/constants/UserRole.js';
 
 import AdminDashboard from './AdminDashboard.vue';
@@ -54,7 +55,7 @@ export default {
       return this.$route.query.tab;
     },
     isAdmin() {
-      return this.$keycloak.hasResourceRole(KeycloakRole.ADMIN);
+      return getKeycloak().hasResourceRole(KeycloakRole.ADMIN);
     },
     activeComponent() {
       switch (this.activeTab) {

--- a/web-ui/src/components/navbar/CytomineNavbar.vue
+++ b/web-ui/src/components/navbar/CytomineNavbar.vue
@@ -88,6 +88,7 @@ import constants from '@/utils/constants.js';
 import shortcuts from '@/utils/shortcuts.js';
 import { useShortkeys } from '@/utils/use-shortkeys.js';
 import { getCurrentInstance } from 'vue';
+import { getKeycloak } from '@/keycloak.js';
 import { KeycloakRole } from '@/constants/UserRole.js';
 
 export default {
@@ -115,7 +116,7 @@ export default {
   computed: {
     currentUser: get('currentUser/user'),
     isAdmin() {
-      return this.$keycloak.hasResourceRole(KeycloakRole.ADMIN);
+      return getKeycloak().hasResourceRole(KeycloakRole.ADMIN);
     },
     nbActiveProjects() {
       return Object.keys(this.$store.state.projects).length;
@@ -149,7 +150,7 @@ export default {
       try {
         this.$store.dispatch('logout');
         this.changeLanguage();
-        await this.$keycloak.logout();
+        await getKeycloak().logout();
       } catch (error) {
         console.log(error);
         this.$notify({ type: 'error', text: this.$t('notif-error-logout') });

--- a/web-ui/src/components/user/Account.vue
+++ b/web-ui/src/components/user/Account.vue
@@ -153,6 +153,7 @@ import { get } from '@/utils/store-helpers';
 import { changeLanguageMixin } from '@/lang.js';
 import { MyAccount, User } from '@/api';
 import { rolesMapping } from '@/utils/role-utils';
+import { getKeycloak } from '@/keycloak.js';
 import { KeycloakRole, UserRole } from '@/constants/UserRole.js';
 import { useClipboard } from '@vueuse/core';
 import { formatMomentDate } from '@/utils/date';
@@ -187,8 +188,8 @@ export default {
     currentAccount: get('currentUser/account'),
     role() {
       // Guest > User > Admin
-      let key = this.$keycloak.hasResourceRole(KeycloakRole.ADMIN) ? UserRole.ADMIN
-        : this.$keycloak.hasResourceRole(KeycloakRole.USER) ? UserRole.USER : UserRole.GUEST;
+      let key = getKeycloak().hasResourceRole(KeycloakRole.ADMIN) ? UserRole.ADMIN
+        : getKeycloak().hasResourceRole(KeycloakRole.USER) ? UserRole.USER : UserRole.GUEST;
       return rolesMapping[key];
     },
 
@@ -225,7 +226,7 @@ export default {
     },
 
     updatePassword() {
-      this.$keycloak.login({ action: this.passwordCredentials.updateAction });
+      getKeycloak().login({ action: this.passwordCredentials.updateAction });
     },
 
 

--- a/web-ui/src/keycloak.js
+++ b/web-ui/src/keycloak.js
@@ -3,7 +3,7 @@ import constants from './utils/constants';
 
 let _keycloak = null;
 
-function getKeycloak() {
+export function getKeycloak() {
   if (!_keycloak) {
     // Strip /realms/cytomine if present, as Keycloak JS adds it automatically
     let url = constants.IAM_URL;
@@ -23,22 +23,3 @@ function getKeycloak() {
   }
   return _keycloak;
 }
-
-const plugin = {
-  install: Vue => {
-    Object.defineProperty(Vue, '$keycloak', {
-      get() {
-        return getKeycloak();
-      }
-    });
-    Object.defineProperties(Vue.prototype, {
-      $keycloak: {
-        get() {
-          return getKeycloak();
-        },
-      },
-    });
-  },
-};
-
-export default plugin;

--- a/web-ui/src/main.js
+++ b/web-ui/src/main.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import axios from 'axios';
 import constants from '@/utils/constants.js';
+import { getKeycloak } from '@/keycloak.js';
 
 import VueRouter from 'vue-router';
 import router from './routes.js';
@@ -64,22 +65,18 @@ axios.get('/configuration.json').then(response => {
     }
   }
 
-  // Now import and initialize Keycloak with loaded config
-  import('./keycloak').then(module => {
-    const Keycloak = module.default;
-    Vue.use(Keycloak);
-
-    Vue.$keycloak
-      .init({
-        onLoad: 'login-required'
-      })
-      .then(() => {
-        new Vue({
-          render: h => h(App),
-          router,
-          store,
-          i18n
-        }).$mount('#app');
-      });
-  });
+  // Now initialize Keycloak with loaded config
+  const keycloak = getKeycloak();
+  keycloak
+    .init({
+      onLoad: 'login-required'
+    })
+    .then(() => {
+      new Vue({
+        render: h => h(App),
+        router,
+        store,
+        i18n
+      }).$mount('#app');
+    });
 });

--- a/web-ui/src/utils/token-utils.js
+++ b/web-ui/src/utils/token-utils.js
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import { getKeycloak } from '../keycloak.js';
 
 export function appendShortTermToken(url, shortTermToken) {
   if (url === null || shortTermToken === null) {
@@ -12,6 +12,7 @@ export function appendShortTermToken(url, shortTermToken) {
 }
 
 export async function updateToken(minValidity = 70) {
-  await Vue.$keycloak.updateToken(minValidity);
-  return Vue.$keycloak.token;
+  const keycloak = getKeycloak();
+  await keycloak.updateToken(minValidity);
+  return keycloak.token;
 }

--- a/web-ui/tests/unit/components/navbar/CytomineNavbar.test.js
+++ b/web-ui/tests/unit/components/navbar/CytomineNavbar.test.js
@@ -3,6 +3,17 @@ import Vuex from 'vuex';
 
 import CytomineNavbar from '@/components/navbar/CytomineNavbar';
 
+const { keycloak } = vi.hoisted(() => ({
+  keycloak: {
+    hasResourceRole: vi.fn(() => false),
+    logout: vi.fn().mockResolvedValue()
+  }
+}));
+
+vi.mock('@/keycloak.js', () => ({
+  getKeycloak: () => keycloak
+}));
+
 vi.mock('@/lang.js', () => ({
   changeLanguageMixin: {
     methods: {
@@ -18,11 +29,6 @@ describe('CytomineNavbar.vue', () => {
 
   const actions = {
     logout: vi.fn()
-  };
-
-  const keycloak = {
-    hasResourceRole: vi.fn(() => false),
-    logout: vi.fn().mockResolvedValue()
   };
 
   const createWrapper = ({ user = {}, projects = {} } = {}) => {
@@ -47,7 +53,6 @@ describe('CytomineNavbar.vue', () => {
       store,
       mocks: {
         $t: (message) => message,
-        $keycloak: keycloak,
         $notify: vi.fn()
       },
       stubs: {


### PR DESCRIPTION
before #251

Export `getKeycloak()` directly and consume it via import rather than installing a `$keycloak` property on the Vue prototype/global. It is because `Vue.prototype` and `Object.defineProperty(Vue, ...)`, do not exist in Vue 3 anymore, so the module works unchanged across the migration.