### PR TITLE
fix: use ping for readiness probe of pims

### DIFF
--- a/helm/charts/cytomine/templates/pims/pims.yaml
+++ b/helm/charts/cytomine/templates/pims/pims.yaml
@@ -131,7 +131,7 @@ spec:
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: /ims/disk-usage
+              path: /ims/ping
               port: {{ .Values.pims.port }}
             periodSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
closes #1211 